### PR TITLE
Centralize DB connections and logging with verbosity toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,7 +815,7 @@ python3 -c "from src.data.preload_news_opportunities import preload_news_opportu
 ## 📈 Monitoring & Logs
 
 ### Log Locations
-- **Application Logs**: Standard Flask logging
+- **Application Logs**: Unified `PageLogger` with adjustable verbosity via `/api/logging/verbosity`
 - **Scalping Logs**: `logs/scalping_analysis.log`
 - **Scheduler Logs**: Integrated with main application logs
 
@@ -823,6 +823,9 @@ python3 -c "from src.data.preload_news_opportunities import preload_news_opportu
 - **System Status**: `/system_status` page
 - **API Health**: `/api/system_status` endpoint
 - **Database Status**: `/api/test_db` endpoint
+
+### Database Utilities
+- **Reusable Connections**: `DBManager` centralizes database access across web modules
 
 ## 🔮 Future Enhancements
 

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -17,9 +17,11 @@ import pytz
 # Essential imports for remaining functionality
 from src.data.data_fetcher import DataFetcher
 from src.core.config import Config
-from src.core.logger import trading_logger, log_exception, log_user_actions, log_timing, log_info, log_error
+from src.core.logger import log_user_actions, log_timing
 from src.core.recommendation_manager import RecommendationManager
 from src.core.database import save_backtest_result, get_latest_backtest, get_db_connection, ensure_job_schedules_table
+from .utils.page_logger import page_logger
+from .utils.db_manager import DBManager
 from src.core.cache import cache_result, get_cached_result
 from src.trading.trading_strategy import TradingStrategy
 from src.core.market_manager import MarketManager
@@ -28,6 +30,12 @@ from src.core.watchlist_manager import watchlist_manager
 from .helpers import create_api_response, handle_api_error
 # Import and register route blueprints
 from .routes import register_routes
+
+# Initialize logging aliases and database manager
+log_info = page_logger.info
+log_error = page_logger.error
+log_exception = page_logger.exception
+trading_logger = page_logger.logger
 app = Flask(__name__)
 # Register route blueprints
 register_routes(app)
@@ -77,6 +85,7 @@ socketio = SocketIO(
 data_fetcher = DataFetcher()
 trading_strategy = TradingStrategy()
 recommendation_manager = RecommendationManager()
+db_manager = DBManager()
 # index route moved to routes/page_routes.py
 @app.route("/api/dashboard/data")
 def get_dashboard_data():
@@ -1119,20 +1128,12 @@ def backtest_historical_recommendations():
         days_back = int(data.get("days_back", 30))
         strategy_type = data.get("strategy_type", "all")  # all, stocks, crypto
         # Create a connection without RealDictCursor for this function
-        db_cfg = Config.DATABASE_CONFIG
-        conn = psycopg2.connect(
-            host=db_cfg["host"],
-            port=db_cfg["port"],
-            database=db_cfg["database"],
-            user=db_cfg["user"],
-            password=db_cfg["password"],
-        )
-        try:
+        with db_manager.connect(dict_cursor=False) as conn:
             with conn.cursor() as cur:
                 # Build query based on parameters
                 query = """
-                    SELECT 
-                        id, symbol, timestamp, recommendation_type, action, 
+                    SELECT
+                        id, symbol, timestamp, recommendation_type, action,
                         strike_price, days_to_expiry, option_price, sentiment_confidence,
                         historical_confidence, final_confidence, sentiment_score,
                         current_stock_price, reasoning, actual_outcome, 
@@ -1213,20 +1214,11 @@ def get_backtest_recommendations():
         days_back = int(request.args.get("days_back", 30))
         limit = int(request.args.get("limit", 100))
         # Create a connection without RealDictCursor for this function
-        db_cfg = Config.DATABASE_CONFIG
-        conn = psycopg2.connect(
-            host=db_cfg["host"],
-            port=db_cfg["port"],
-            database=db_cfg["database"],
-            user=db_cfg["user"],
-            password=db_cfg["password"],
-            cursor_factory=None,  # Use default cursor (tuples)
-        )
-        try:
+        with db_manager.connect(dict_cursor=False) as conn:
             with conn.cursor() as cur:
                 query = """
-                    SELECT 
-                        id, symbol, timestamp, recommendation_type, action, 
+                    SELECT
+                        id, symbol, timestamp, recommendation_type, action,
                         strike_price, current_stock_price, sentiment_confidence,
                         final_confidence, sentiment_score, reasoning,
                         actual_outcome, outcome_timestamp, profitable
@@ -1282,20 +1274,11 @@ def get_backtest_statistics():
         days_back = int(request.args.get("days_back", 30))
         symbol = request.args.get("symbol", "").upper()
         # Create a connection without RealDictCursor for this function
-        db_cfg = Config.DATABASE_CONFIG
-        conn = psycopg2.connect(
-            host=db_cfg["host"],
-            port=db_cfg["port"],
-            database=db_cfg["database"],
-            user=db_cfg["user"],
-            password=db_cfg["password"],
-            cursor_factory=None,  # Use default cursor (tuples)
-        )
-        try:
+        with db_manager.connect(dict_cursor=False) as conn:
             with conn.cursor() as cur:
                 # Build base query
                 base_query = f"""
-                    FROM recommendations 
+                    FROM recommendations
                     WHERE timestamp >= NOW() - INTERVAL '{days_back} days'
                 """
                 params = []

--- a/src/web/routes/system_routes.py
+++ b/src/web/routes/system_routes.py
@@ -16,12 +16,15 @@ from ..helpers import (
 )
 
 # Import core modules
-from ...core.logger import trading_logger, log_exception
 from ...core.database import get_db_connection
 from ...core.config import Config
+from ..utils.page_logger import page_logger
 
 # Create blueprint
 system_bp = Blueprint('system', __name__)
+
+log_exception = page_logger.exception
+trading_logger = page_logger.logger
 
 
 @system_bp.route("/system_status")
@@ -268,6 +271,20 @@ def get_logs():
                 
     except Exception as e:
         return handle_api_error(e, "get_logs endpoint")
+
+
+@system_bp.route("/api/logging/verbosity", methods=["GET", "POST"])
+def logging_verbosity():
+    """Get or update logging verbosity."""
+    try:
+        if request.method == "POST":
+            data = request.get_json(force=True) or {}
+            verbose = bool(data.get("verbose", True))
+            page_logger.set_verbose(verbose)
+            return create_api_response(data={"verbose": page_logger.verbose})
+        return create_api_response(data={"verbose": page_logger.verbose})
+    except Exception as e:
+        return handle_api_error(e, "logging_verbosity endpoint")
 
 
 @system_bp.route("/api/news_services/toggle", methods=["POST"])

--- a/src/web/templates/logs.html
+++ b/src/web/templates/logs.html
@@ -67,6 +67,13 @@
                                 Auto-refresh every 10 seconds
                             </label>
                         </div>
+        
+                        <div class="form-check form-switch mt-2">
+                            <input class="form-check-input" type="checkbox" id="verboseToggle" checked>
+                            <label class="form-check-label" for="verboseToggle">
+                                Verbose Logging
+                            </label>
+                        </div>
                     </div>
                     <div class="col-md-6 text-end">
                         <div class="btn-group" role="group">
@@ -149,6 +156,7 @@ let currentLogs = [];
 document.addEventListener('DOMContentLoaded', function() {
     loadLogs();
     setupEventListeners();
+    initVerboseToggle();
 });
 
 function setupEventListeners() {
@@ -157,6 +165,9 @@ function setupEventListeners() {
     
     // Auto-refresh toggle
     document.getElementById('autoRefreshLogs').addEventListener('change', toggleAutoRefresh);
+
+    // Verbose logging toggle
+    document.getElementById('verboseToggle').addEventListener('change', toggleVerbose);
     
     // Filter changes
     document.getElementById('logType').addEventListener('change', loadLogs);
@@ -357,6 +368,29 @@ function toggleAutoRefresh() {
             autoRefreshInterval = null;
         }
         showAlert('Auto-refresh disabled', 'info');
+    }
+}
+
+async function initVerboseToggle() {
+    try {
+        const res = await fetch('/api/logging/verbosity');
+        const data = await res.json();
+        document.getElementById('verboseToggle').checked = data.data?.verbose;
+    } catch (error) {
+        console.error('Error loading verbosity state', error);
+    }
+}
+
+async function toggleVerbose() {
+    const verbose = document.getElementById('verboseToggle').checked;
+    try {
+        await fetch('/api/logging/verbosity', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ verbose })
+        });
+    } catch (error) {
+        console.error('Error toggling verbosity', error);
     }
 }
 

--- a/src/web/utils/db_manager.py
+++ b/src/web/utils/db_manager.py
@@ -1,0 +1,42 @@
+from contextlib import contextmanager
+import psycopg2
+from src.core.database import get_db_connection
+from src.core.config import Config
+
+
+class DBManager:
+    """Reusable database connection manager for web components."""
+
+    def __init__(self):
+        self.db_url = getattr(Config, "DATABASE_URL", None)
+        self.db_cfg = getattr(Config, "DATABASE_CONFIG", {})
+
+    @contextmanager
+    def connect(self, dict_cursor: bool = True):
+        """Yield a database connection.
+
+        Args:
+            dict_cursor: When True, use core get_db_connection which returns
+                RealDictCursor. When False, return a basic psycopg2 connection
+                without special cursor factory for raw access.
+        """
+        if dict_cursor:
+            with get_db_connection() as conn:
+                yield conn
+        else:
+            conn = None
+            try:
+                if self.db_url:
+                    conn = psycopg2.connect(self.db_url)
+                else:
+                    conn = psycopg2.connect(
+                        host=self.db_cfg.get("host"),
+                        port=self.db_cfg.get("port"),
+                        database=self.db_cfg.get("database"),
+                        user=self.db_cfg.get("user"),
+                        password=self.db_cfg.get("password"),
+                    )
+                yield conn
+            finally:
+                if conn:
+                    conn.close()

--- a/src/web/utils/page_logger.py
+++ b/src/web/utils/page_logger.py
@@ -1,0 +1,50 @@
+import logging
+from src.core.logger import trading_logger as _core_logger
+
+
+class PageLogger:
+    """Wrapper around the core trading logger with verbosity control."""
+
+    def __init__(self):
+        self.base_logger = _core_logger
+        self.verbose = True
+        self._set_level()
+
+    def _set_level(self):
+        level = logging.DEBUG if self.verbose else logging.INFO
+        # Adjust levels for relevant loggers except error logger
+        for logger in [
+            self.base_logger.app_logger,
+            self.base_logger.api_logger,
+            self.base_logger.user_logger,
+            self.base_logger.system_logger,
+            self.base_logger.perf_logger,
+        ]:
+            logger.setLevel(level)
+
+    def set_verbose(self, verbose: bool):
+        """Toggle verbose logging."""
+        self.verbose = verbose
+        self._set_level()
+
+    # Expose logging methods with extensive defaults
+    def info(self, message, category: str = "app"):
+        self.base_logger.info(message, category=category)
+
+    def error(self, message, category: str = "error", exc_info=None):
+        self.base_logger.error(message, category=category, exc_info=exc_info)
+
+    def debug(self, message, category: str = "app"):
+        if self.verbose:
+            logger = getattr(self.base_logger, f"{category}_logger", self.base_logger.app_logger)
+            logger.debug(message)
+
+    def exception(self, operation, exception, context=None):
+        self.base_logger.log_exception(operation, exception, context)
+
+    @property
+    def logger(self):
+        """Expose underlying logger for compatibility."""
+        return self.base_logger
+
+page_logger = PageLogger()


### PR DESCRIPTION
## Summary
- Replace direct database handling in `app.py` with a reusable `DBManager` and expose logging aliases through `PageLogger`
- Provide a context manager for raw or dictionary-based database cursors via `DBManager`
- Add `PageLogger` with adjustable verbosity and use it across routes
- Introduce `/api/logging/verbosity` endpoint and a UI toggle on the logs page to control log verbosity
- Document new `PageLogger` and `DBManager` utilities in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.core.config'; No module named 'playwright'; No module named 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68b25f526940832ab541eae1829007af