### PR TITLE
chore: split error handling plan

### DIFF
--- a/00_app_refactor.md
+++ b/00_app_refactor.md
@@ -37,14 +37,7 @@ The current `app.py` file is **5,861 lines** and violates multiple software engi
 - **Add query performance monitoring**: Track slow queries and optimize
 - **Implement proper transaction management**: ACID compliance and rollback handling
 
-#### 1.3 Error Handling & Logging Infrastructure
-- **Centralized error handling**: Implement global error handlers
-- **Structured logging**: Use structured logging with proper levels
-- **Error tracking**: Integrate with error tracking services (Sentry, etc.)
-- **Performance monitoring**: Add request timing and performance metrics
-- **Health check endpoints**: Implement application health monitoring
-
-#### 1.4 Configuration Management
+#### 1.3 Configuration Management
 - **Environment-based config**: Separate dev/staging/prod configurations
 - **Configuration validation**: Validate all configuration values at startup
 - **Secret management**: Use proper secret management (AWS Secrets Manager, etc.)

--- a/00_error_handling.md
+++ b/00_error_handling.md
@@ -1,0 +1,7 @@
+# Error Handling & Logging Infrastructure
+
+- **Centralized error handling**: Implement global error handlers
+- **Structured logging**: Use structured logging with proper levels
+- **Error tracking**: Integrate with error tracking services (Sentry, etc.)
+- **Performance monitoring**: Add request timing and performance metrics
+- **Health check endpoints**: Implement application health monitoring


### PR DESCRIPTION
## Summary
- remove error handling section from refactor plan
- add dedicated error handling and logging document

## Testing
- `python tests/run_tests.py --unit-only` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b503b26d78832a869bea29faef2069