### PR TITLE
refactor: move client logging endpoints to blueprint

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -39,26 +39,6 @@ trading_logger = page_logger.logger
 app = Flask(__name__)
 # Register route blueprints
 register_routes(app)
-# --- Client Error Logging Endpoint ---
-@app.route("/api/log_client_error", methods=["POST"])
-def log_client_error():
-    """Log client-side JS errors from the frontend."""
-    try:
-        data = request.get_json(force=True)
-        page = data.get("page", "unknown")
-        error = data.get("error", "No error message")
-        stack = data.get("stack", "No stack trace")
-        timestamp = data.get("timestamp", datetime.now().isoformat())
-        log_message = f"[CLIENT ERROR] Page: {page} | Error: {error} | Stack: {stack} | Timestamp: {timestamp}"
-        trading_logger.error_logger.error(log_message)
-        log_exception(f"Client error on {page}", error)
-        return create_api_response(message="Error logged successfully")
-    except Exception as e:
-        return handle_api_error(e, "log_client_error endpoint")
-@app.route("/api/frontend_logs", methods=["POST"])
-def frontend_logs():
-    """Alternative endpoint for frontend logging (compatibility)"""
-    return log_client_error()
 # Enable CORS for all routes
 CORS(
     app,

--- a/src/web/routes/__init__.py
+++ b/src/web/routes/__init__.py
@@ -11,6 +11,7 @@ def register_routes(app):
     from .system_routes import system_bp
     from .page_routes import page_bp
     from .telegram_routes import telegram_bp
+    from .logging_routes import logging_bp
     
     # Register blueprints
     app.register_blueprint(analysis_bp)
@@ -18,6 +19,7 @@ def register_routes(app):
     app.register_blueprint(system_bp)
     app.register_blueprint(page_bp)
     app.register_blueprint(telegram_bp)
+    app.register_blueprint(logging_bp)
     
     # Register scalping signals blueprint
     try:

--- a/src/web/routes/logging_routes.py
+++ b/src/web/routes/logging_routes.py
@@ -1,0 +1,37 @@
+from flask import Blueprint, request
+from datetime import datetime
+
+from ..helpers import create_api_response, handle_api_error
+from ..utils.page_logger import page_logger
+
+logging_bp = Blueprint("logging", __name__)
+
+# Access the underlying trading logger and exception helper
+trading_logger = page_logger.logger
+log_exception = page_logger.exception
+
+
+@logging_bp.route("/api/log_client_error", methods=["POST"])
+def log_client_error():
+    """Log client-side JavaScript errors from the frontend."""
+    try:
+        data = request.get_json(force=True)
+        page = data.get("page", "unknown")
+        error = data.get("error", "No error message")
+        stack = data.get("stack", "No stack trace")
+        timestamp = data.get("timestamp", datetime.now().isoformat())
+        log_message = (
+            f"[CLIENT ERROR] Page: {page} | Error: {error} | "
+            f"Stack: {stack} | Timestamp: {timestamp}"
+        )
+        trading_logger.error_logger.error(log_message)
+        log_exception(f"Client error on {page}", error)
+        return create_api_response(message="Error logged successfully")
+    except Exception as e:  # pragma: no cover - safeguard
+        return handle_api_error(e, "log_client_error endpoint")
+
+
+@logging_bp.route("/api/frontend_logs", methods=["POST"])
+def frontend_logs():
+    """Alternative endpoint for frontend logging (compatibility)."""
+    return log_client_error()


### PR DESCRIPTION
## Summary
- extract client-side logging endpoints into dedicated `logging_routes` blueprint
- register new blueprint in routes package
- streamline `app.py` by removing inline logging routes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.core.config', 'playwright', 'selenium')*

------
https://chatgpt.com/codex/tasks/task_e_68bdbfe8d518832ab2194d5d6a26fff7