### PR TITLE
Add request context to API error responses

### DIFF
--- a/src/web/helpers.py
+++ b/src/web/helpers.py
@@ -15,12 +15,26 @@ from .repositories import market_data_repo
 from ..core.logger import log_exception
 
 
-def create_api_response(data=None, success=True, message="", error_code=None, error=None, status_code=200):
+def create_api_response(data=None, success=True, message="", error_code=None,
+                        error=None, status_code=200, path: str = None,
+                        method: str = None):
     """Create standardized API response using optimized formatter"""
     if error or not success:
-        response = format_error_response(error or "Operation failed", error_code=error_code)
+        if path is None or method is None:
+            try:
+                path = path or request.path
+                method = method or request.method
+            except RuntimeError:
+                # Request context may not be available
+                pass
+        response = format_error_response(
+            error or "Operation failed",
+            error_code=error_code,
+            path=path,
+            method=method
+        )
         return jsonify(response), status_code
-    
+
     response = format_api_response(data, message)
     return jsonify(response), status_code
 
@@ -31,7 +45,9 @@ def handle_api_error(e, context="API operation"):
     return create_api_response(
         success=False,
         error=str(e),
-        status_code=500
+        status_code=500,
+        path=request.path,
+        method=request.method
     )
 
 

--- a/src/web/utils/formatters.py
+++ b/src/web/utils/formatters.py
@@ -146,32 +146,41 @@ def format_api_response(data: Any = None, message: str = "Success",
 
 
 def format_error_response(error: Union[str, Exception], error_code: str = None,
-                         details: Dict = None) -> Dict:
+                         details: Dict = None, path: Optional[str] = None,
+                         method: Optional[str] = None) -> Dict:
     """
     Optimized error response formatter
-    
+
     Args:
         error: Error message or exception
         error_code: Optional error code
         details: Additional error details
-        
+        path: Optional request path where the error occurred
+        method: Optional HTTP method of the request
+
     Returns:
         Formatted error response dictionary
     """
     error_message = str(error)
-    
+
     response = {
         "status": "error",
         "error": error_message,
         "timestamp": datetime.now().isoformat()
     }
-    
+
     if error_code:
         response["error_code"] = error_code
-    
+
     if details:
         response["details"] = details
-    
+
+    if path:
+        response["path"] = path
+
+    if method:
+        response["method"] = method
+
     return response
 
 


### PR DESCRIPTION
## Summary
- include optional `path` and `method` metadata in formatted error responses
- propagate request path and method through `create_api_response`
- ensure `handle_api_error` attaches request context for consistent API error JSON

## Testing
- `python tests/run_tests.py --unit-only` *(fails: ModuleNotFoundError: No module named 'src.core.config')*

------
https://chatgpt.com/codex/tasks/task_e_68c46e1e2558832ab7da87d5a86cab2f