### PR TITLE
chore: apply api error decorator

### DIFF
--- a/src/web/routes/analysis_routes.py
+++ b/src/web/routes/analysis_routes.py
@@ -8,14 +8,13 @@ import time
 
 # Import helper functions
 from ..helpers import (
-    create_api_response, 
-    handle_api_error, 
-    get_request_params, 
-    validate_symbol, 
-    execute_db_query, 
+    create_api_response,
+    get_request_params,
+    validate_symbol,
+    execute_db_query,
     get_preloaded_opportunities,
-    api_error_handler
 )
+from ..utils import api_error_handler
 
 # Import core modules
 from ...core.logger import trading_logger, log_info, log_error, log_exception, log_timing, log_user_actions
@@ -28,112 +27,107 @@ analysis_bp = Blueprint('analysis', __name__)
 
 
 @analysis_bp.route("/api/analyze_stock", methods=["POST"])
+@api_error_handler("analyze_stock")
 @log_user_actions(trading_logger)
 @log_timing(trading_logger)
 def analyze_stock():
     """Analyze a single stock"""
-    try:
-        data = request.get_json()
+    data = request.get_json()
+    trading_logger.api_logger.info(
+        f"[DEBUG] Incoming /api/analyze_stock request: {data}"
+    )
+    if not data or "symbol" not in data:
         trading_logger.api_logger.info(
-            f"[DEBUG] Incoming /api/analyze_stock request: {data}"
+            f"[DEBUG] /api/analyze_stock missing symbol: {data}"
         )
-        if not data or "symbol" not in data:
-            trading_logger.api_logger.info(
-                f"[DEBUG] /api/analyze_stock missing symbol: {data}"
-            )
-            return create_api_response(
-                error="Missing required parameter: symbol",
-                status_code=400
-            )
-        
-        symbol = data["symbol"].strip().upper() if data["symbol"] else ""
-        if not symbol:
-            trading_logger.api_logger.info(
-                f"[DEBUG] /api/analyze_stock empty symbol: {data}"
-            )
-            return create_api_response(
-                error="Symbol cannot be empty",
-                status_code=400
-            )
-
-        # Use the analysis service
-        result = analysis_service.analyze_single_stock(symbol, use_cache=True)
-        
-        if "error" in result:
-            return create_api_response(
-                error=result["error"],
-                status_code=500
-            )
-
         return create_api_response(
-            data=result,
-            message="Stock analysis completed successfully"
+            error="Missing required parameter: symbol",
+            status_code=400
         )
-    except Exception as e:
-        return handle_api_error(e, "analyze_stock endpoint")
+
+    symbol = data["symbol"].strip().upper() if data["symbol"] else ""
+    if not symbol:
+        trading_logger.api_logger.info(
+            f"[DEBUG] /api/analyze_stock empty symbol: {data}"
+        )
+        return create_api_response(
+            error="Symbol cannot be empty",
+            status_code=400
+        )
+
+    # Use the analysis service
+    result = analysis_service.analyze_single_stock(symbol, use_cache=True)
+
+    if "error" in result:
+        return create_api_response(
+            error=result["error"],
+            status_code=500
+        )
+
+    return create_api_response(
+        data=result,
+        message="Stock analysis completed successfully"
+    )
 
 
 @analysis_bp.route("/api/analyze_bulk", methods=["POST"])
+@api_error_handler("analyze_bulk")
 def analyze_bulk():
     """Analyze multiple stocks with rate limiting and batching"""
-    try:
-        data = request.get_json()
-        if not data or "symbols" not in data:
-            return create_api_response(
-                error="Missing required parameter: symbols",
-                status_code=400
-            )
+    data = request.get_json()
+    if not data or "symbols" not in data:
+        return create_api_response(
+            error="Missing required parameter: symbols",
+            status_code=400
+        )
 
-        symbols = data["symbols"]
-        if not isinstance(symbols, list) or len(symbols) == 0:
-            return create_api_response(
-                error="Symbols must be a non-empty list",
-                status_code=400
-            )
+    symbols = data["symbols"]
+    if not isinstance(symbols, list) or len(symbols) == 0:
+        return create_api_response(
+            error="Symbols must be a non-empty list",
+            status_code=400
+        )
 
-        # Limit batch size
-        if len(symbols) > 10:
-            return create_api_response(
-                error="Maximum 10 symbols allowed per batch",
-                status_code=400
-            )
+    # Limit batch size
+    if len(symbols) > 10:
+        return create_api_response(
+            error="Maximum 10 symbols allowed per batch",
+            status_code=400
+        )
 
-        # Clean and validate symbols
-        clean_symbols = []
-        for symbol in symbols:
-            symbol = symbol.strip().upper()
-            if symbol:
-                clean_symbols.append(symbol)
+    # Clean and validate symbols
+    clean_symbols = []
+    for symbol in symbols:
+        symbol = symbol.strip().upper()
+        if symbol:
+            clean_symbols.append(symbol)
 
-        # Use the analysis service for bulk processing
-        result = analysis_service.analyze_bulk_stocks(clean_symbols, max_concurrent=5)
-        
-        return create_api_response(data=result)
-    except Exception as e:
-        return handle_api_error(e, "analyze_bulk endpoint")
+    # Use the analysis service for bulk processing
+    result = analysis_service.analyze_bulk_stocks(clean_symbols, max_concurrent=5)
+
+    return create_api_response(data=result)
 
 
 @analysis_bp.route("/api/stock/<symbol>/analysis")
+@api_error_handler("analyze_stock_by_symbol")
 def analyze_stock_by_symbol(symbol):
     """Get stock analysis by symbol"""
-    try:
-        if not symbol:
-            return create_api_response(
-                error="Symbol parameter is required",
-                status_code=400
-            )
+    if not symbol:
+        return create_api_response(
+            error="Symbol parameter is required",
+            status_code=400
+        )
 
-        symbol = symbol.strip().upper()
-        
-        # Use the analysis service
-        result = analysis_service.analyze_single_stock(symbol, use_cache=True)
-        
-        return create_api_response(data=result)
-    except Exception as e:
-        return handle_api_error(e, "analyze_stock_by_symbol endpoint")
+    symbol = symbol.strip().upper()
+
+    # Use the analysis service
+    result = analysis_service.analyze_single_stock(symbol, use_cache=True)
+
+    return create_api_response(data=result)
 
 
 @analysis_bp.route("/api/sp500_analysis")
+@api_error_handler("sp500_analysis")
 def sp500_analysis():
     """API endpoint for S&P 500 winners and losers analysis"""
     try:
@@ -156,175 +150,154 @@ def sp500_analysis():
 
 
 @analysis_bp.route("/api/crypto_analysis")
+@api_error_handler("crypto_analysis")
 def crypto_analysis():
     """Analyze cryptocurrencies for trading opportunities with fast preload"""
-    try:
-        # Get query parameters
-        refresh_requested = request.args.get('refresh', '0') == '1'
-        
-        # Use the analysis service for crypto analysis
-        result = analysis_service.get_crypto_analysis(refresh=refresh_requested)
-        
-        return create_api_response(data=result)
+    # Get query parameters
+    refresh_requested = request.args.get('refresh', '0') == '1'
 
-    except Exception as e:
-        return handle_api_error(e, "crypto_analysis endpoint")
+    # Use the analysis service for crypto analysis
+    result = analysis_service.get_crypto_analysis(refresh=refresh_requested)
+
+    return create_api_response(data=result)
 
 
 @analysis_bp.route("/api/enhanced_analysis", methods=["POST"])
+@api_error_handler("enhanced_analysis")
 @log_user_actions(trading_logger)
 @log_timing(trading_logger)
 def enhanced_analysis():
     """Enhanced stock analysis with multiple strategies and backtesting"""
-    try:
-        data = request.get_json()
-        if not data or "symbol" not in data:
-            return create_api_response(
-                error="Missing required parameter: symbol",
-                status_code=400
-            )
-
-        symbol = data["symbol"].strip().upper()
-        if not symbol:
-            return create_api_response(
-                error="Symbol cannot be empty",
-                status_code=400
-            )
-
-        # Import the enhanced trading strategy for comprehensive recommendations
-        from ...trading.enhanced_trading_strategy import EnhancedTradingStrategy
-        from ...data.data_fetcher import DataFetcher
-        from ...core.sentiment_analyzer import SentimentAnalyzer
-        
-        # Initialize components
-        enhanced_strategy = EnhancedTradingStrategy()
-        data_fetcher = DataFetcher()
-        sentiment_analyzer = SentimentAnalyzer()
-        
-        # Get market data
-        price_data = data_fetcher.get_stock_price(symbol)
-        if not price_data or "current_price" not in price_data:
-            return create_api_response(
-                error=f"Could not fetch price data for {symbol}",
-                status_code=400
-            )
-        
-        # Get news and analyze sentiment with aggressive filtering for enhanced analysis
-        news_data = data_fetcher.get_company_news(symbol, days_back=2)  # More recent news for enhanced
-        if len(news_data) > 3:  # Strict limit for enhanced analysis 
-            news_data = news_data[:3]
-        
-        # Use fast fallback for sentiment if news is very limited
-        if len(news_data) < 2:
-            sentiment_data = {
-                "sentiment_score": 0.1,  # Slightly positive default
-                "confidence": 0.6,
-                "summary": "Enhanced analysis with limited news data"
-            }
-        else:
-            sentiment_data = sentiment_analyzer.analyze_news_sentiment(news_data, symbol=symbol)
-        signal_data = sentiment_analyzer.get_trading_signal(sentiment_data)
-        
-        # Generate comprehensive recommendations with multiple strategies and 2-YEAR historical backtesting
-        recommendations = enhanced_strategy.get_comprehensive_recommendations(
-            symbol, price_data["current_price"], sentiment_data, signal_data
+    data = request.get_json()
+    if not data or "symbol" not in data:
+        return create_api_response(
+            error="Missing required parameter: symbol",
+            status_code=400
         )
-        
-        # Force 2-year historical backtesting for enhanced analysis
-        if recommendations and "all_recommendations" in recommendations:
-            for rec in recommendations["all_recommendations"]:
-                if "historical_stats" in rec:
-                    # Ensure we have proper historical data (730 days = 2 years)
-                    if rec["historical_stats"].get("total_trades", 0) < 10:
-                        print(f"⚠️ Enhanced Analysis: {symbol} has insufficient historical data for proper backtesting")
-        
-        response_data = {
+
+    symbol = data["symbol"].strip().upper()
+    if not symbol:
+        return create_api_response(
+            error="Symbol cannot be empty",
+            status_code=400
+        )
+
+    from ...trading.enhanced_trading_strategy import EnhancedTradingStrategy
+    from ...data.data_fetcher import DataFetcher
+    from ...core.sentiment_analyzer import SentimentAnalyzer
+
+    enhanced_strategy = EnhancedTradingStrategy()
+    data_fetcher = DataFetcher()
+    sentiment_analyzer = SentimentAnalyzer()
+
+    price_data = data_fetcher.get_stock_price(symbol)
+    if not price_data or "current_price" not in price_data:
+        return create_api_response(
+            error=f"Could not fetch price data for {symbol}",
+            status_code=400
+        )
+
+    news_data = data_fetcher.get_company_news(symbol, days_back=2)
+    if len(news_data) > 3:
+        news_data = news_data[:3]
+
+    if len(news_data) < 2:
+        sentiment_data = {
+            "sentiment_score": 0.1,
+            "confidence": 0.6,
+            "summary": "Enhanced analysis with limited news data",
+        }
+    else:
+        sentiment_data = sentiment_analyzer.analyze_news_sentiment(news_data, symbol=symbol)
+    signal_data = sentiment_analyzer.get_trading_signal(sentiment_data)
+
+    recommendations = enhanced_strategy.get_comprehensive_recommendations(
+        symbol, price_data["current_price"], sentiment_data, signal_data
+    )
+
+    if recommendations and "all_recommendations" in recommendations:
+        for rec in recommendations["all_recommendations"]:
+            if "historical_stats" in rec:
+                if rec["historical_stats"].get("total_trades", 0) < 10:
+                    print(f"⚠️ Enhanced Analysis: {symbol} has insufficient historical data for proper backtesting")
+
+    response_data = {
+        "symbol": symbol,
+        "price_data": price_data,
+        "sentiment_data": sentiment_data,
+        "signal_data": signal_data,
+        "news_count": len(news_data),
+        "enhanced_analysis": {
             "symbol": symbol,
             "price_data": price_data,
             "sentiment_data": sentiment_data,
             "signal_data": signal_data,
-            "news_count": len(news_data),
-            "enhanced_analysis": {
+            "recommendations": recommendations,
+            "news_data": {"article_count": len(news_data)},
+            "analysis_type": "enhanced",
+        },
+        "timestamp": datetime.now().isoformat(),
+    }
+
+    return create_api_response(
+        data=response_data,
+        message="Enhanced analysis with multiple strategies completed successfully",
+    )
+
+
+@analysis_bp.route("/api/comprehensive_analysis", methods=["POST"])
+@api_error_handler("comprehensive_analysis")
+def comprehensive_analysis():
+    """Enhanced analysis with both stock and options recommendations"""
+    data = request.get_json()
+    symbol = data.get("symbol", "").upper()
+    ai_provider = data.get("ai_provider", "ollama")
+
+    if not symbol:
+        return create_api_response(error="Symbol is required", status_code=400)
+
+    from ...trading.trading_strategy import TradingStrategy
+    from ...data.data_fetcher import DataFetcher
+    from ...core.sentiment_analyzer import SentimentAnalyzer
+
+    trading_strategy = TradingStrategy()
+    data_fetcher = DataFetcher()
+    sentiment_analyzer = SentimentAnalyzer()
+
+    price_data = data_fetcher.get_stock_price(symbol)
+    if not price_data or "current_price" not in price_data:
+        return create_api_response(
+            error=f"Could not fetch price data for {symbol}",
+            status_code=400
+        )
+
+    news_data = data_fetcher.get_company_news(symbol, days_back=3)
+    if len(news_data) > 5:
+        news_data = news_data[:5]
+
+    sentiment_data = sentiment_analyzer.analyze_news_sentiment(news_data, symbol=symbol)
+    signal_data = sentiment_analyzer.get_trading_signal(sentiment_data)
+
+    recommendation = trading_strategy.get_recommendation(
+        symbol, price_data, sentiment_data, signal_data
+    )
+
+    return create_api_response(
+        data={
+            "symbol": symbol,
+            "comprehensive_analysis": {
                 "symbol": symbol,
                 "price_data": price_data,
                 "sentiment_data": sentiment_data,
                 "signal_data": signal_data,
-                "recommendations": recommendations,
+                "recommendation": recommendation,
                 "news_data": {"article_count": len(news_data)},
-                "analysis_type": "enhanced"
+                "analysis_type": "standard"
             },
-            "timestamp": datetime.now().isoformat(),
+            "ai_provider_used": ai_provider,
+            "timestamp": datetime.now().isoformat()
         }
-        
-        return create_api_response(
-            data=response_data,
-            message="Enhanced analysis with multiple strategies completed successfully"
-        )
-    except Exception as e:
-        return handle_api_error(e, "enhanced_analysis endpoint")
-
-
-@analysis_bp.route("/api/comprehensive_analysis", methods=["POST"])
-def comprehensive_analysis():
-    """Enhanced analysis with both stock and options recommendations"""
-    try:
-        data = request.get_json()
-        symbol = data.get("symbol", "").upper()
-        ai_provider = data.get("ai_provider", "ollama")
-        
-        if not symbol:
-            return create_api_response(error="Symbol is required", status_code=400)
-        
-        # Use basic trading strategy for standard comprehensive analysis
-        from ...trading.trading_strategy import TradingStrategy
-        from ...data.data_fetcher import DataFetcher
-        from ...core.sentiment_analyzer import SentimentAnalyzer
-        
-        # Initialize components
-        trading_strategy = TradingStrategy()
-        data_fetcher = DataFetcher()
-        sentiment_analyzer = SentimentAnalyzer()
-        
-        # Get market data
-        price_data = data_fetcher.get_stock_price(symbol)
-        if not price_data or "current_price" not in price_data:
-            return create_api_response(
-                error=f"Could not fetch price data for {symbol}",
-                status_code=400
-            )
-        
-        # Get news and analyze sentiment with broader scope for standard analysis
-        news_data = data_fetcher.get_company_news(symbol, days_back=3)  # Different timeframe for standard
-        if len(news_data) > 5:  # More articles for standard analysis
-            news_data = news_data[:5]
-        
-        # Always use sentiment analysis for standard (no fallback)
-        sentiment_data = sentiment_analyzer.analyze_news_sentiment(news_data, symbol=symbol)
-        signal_data = sentiment_analyzer.get_trading_signal(sentiment_data)
-        
-        # Generate single basic recommendation using standard trading strategy
-        recommendation = trading_strategy.get_recommendation(
-            symbol, price_data, sentiment_data, signal_data
-        )
-        
-        return create_api_response(
-            data={
-                "symbol": symbol,
-                "comprehensive_analysis": {
-                    "symbol": symbol,
-                    "price_data": price_data,
-                    "sentiment_data": sentiment_data,
-                    "signal_data": signal_data,
-                    "recommendation": recommendation,
-                    "news_data": {"article_count": len(news_data)},
-                    "analysis_type": "standard"
-                },
-                "ai_provider_used": ai_provider,
-                "timestamp": datetime.now().isoformat()
-            }
-        )
-    except Exception as e:
-        return handle_api_error(e, "comprehensive_analysis endpoint")
+    )
 
 
 # analyze_single_stock function moved to services/analysis_service.py

--- a/src/web/routes/backtest_routes.py
+++ b/src/web/routes/backtest_routes.py
@@ -8,13 +8,12 @@ import json
 
 # Import helper functions
 from ..helpers import (
-    create_api_response, 
-    handle_api_error, 
-    get_request_params, 
-    validate_symbol, 
-    execute_db_query, 
-    api_error_handler
+    create_api_response,
+    get_request_params,
+    validate_symbol,
+    execute_db_query,
 )
+from ..utils import api_error_handler
 
 # Import core modules
 from ...core.logger import trading_logger, log_exception
@@ -33,111 +32,95 @@ def backtest_page():
 
 
 @backtest_bp.route("/api/backtest", methods=["POST"])
+@api_error_handler("backtest")
 def backtest():
     """Run backtest for a symbol, with DB persistence and prepopulation."""
-    try:
-        data = request.get_json()
-        if not data:
-            return create_api_response(
-                error="Request body is required",
-                status_code=400
-            )
+    data = request.get_json()
+    if not data:
+        return create_api_response(
+            error="Request body is required",
+            status_code=400
+        )
 
-        symbol = data.get("symbol", "").strip().upper()
-        if not symbol:
-            return create_api_response(
-                error="Symbol is required",
-                status_code=400
-            )
+    symbol = data.get("symbol", "").strip().upper()
+    if not symbol:
+        return create_api_response(
+            error="Symbol is required",
+            status_code=400
+        )
 
-        # Get backtest parameters
-        days_back = int(data.get("days_back", 30))
-        initial_capital = float(data.get("initial_capital", 10000))
+    # Get backtest parameters
+    days_back = int(data.get("days_back", 30))
+    initial_capital = float(data.get("initial_capital", 10000))
 
-        # Use the backtest service
-        result = backtest_service.run_backtest(symbol, days_back, initial_capital)
-        
-        if "error" in result:
-            return create_api_response(
-                error=result["error"],
-                status_code=500
-            )
+    # Use the backtest service
+    result = backtest_service.run_backtest(symbol, days_back, initial_capital)
 
-        return create_api_response(data=result)
+    if "error" in result:
+        return create_api_response(
+            error=result["error"],
+            status_code=500
+        )
 
-    except Exception as e:
-        return handle_api_error(e, "backtest endpoint")
+    return create_api_response(data=result)
 
 
 @backtest_bp.route("/api/backtest/historical", methods=["POST"])
+@api_error_handler("backtest_historical")
 def backtest_historical_recommendations():
     """Run backtest based on historical recommendations from the database."""
-    try:
-        data = request.get_json()
-        if not data:
-            return create_api_response(
-                error="Request body is required",
-                status_code=400
-            )
+    data = request.get_json()
+    if not data:
+        return create_api_response(
+            error="Request body is required",
+            status_code=400
+        )
 
-        symbol = data.get("symbol", "").strip().upper()
-        days_back = int(data.get("days_back", 30))
-        initial_capital = float(data.get("initial_capital", 10000))
+    symbol = data.get("symbol", "").strip().upper()
+    days_back = int(data.get("days_back", 30))
+    initial_capital = float(data.get("initial_capital", 10000))
 
-        # Get historical recommendations using the service
-        recommendations_data = backtest_service.get_backtest_recommendations(symbol, days_back)
-        recommendations = recommendations_data.get("recommendations", [])
-        
-        if not recommendations:
-            return create_api_response(
-                data={
-                    "symbol": symbol,
-                    "trades": [],
-                    "total_return": 0,
-                    "message": "No historical recommendations found"
-                }
-            )
+    recommendations_data = backtest_service.get_backtest_recommendations(symbol, days_back)
+    recommendations = recommendations_data.get("recommendations", [])
 
-        # Process recommendations into backtest results using the service
-        backtest_results = backtest_service.process_historical_recommendations(recommendations)
+    if not recommendations:
+        return create_api_response(
+            data={
+                "symbol": symbol,
+                "trades": [],
+                "total_return": 0,
+                "message": "No historical recommendations found",
+            }
+        )
 
-        return create_api_response(data=backtest_results)
+    backtest_results = backtest_service.process_historical_recommendations(recommendations)
 
-    except Exception as e:
-        return handle_api_error(e, "backtest_historical endpoint")
+    return create_api_response(data=backtest_results)
 
 
 @backtest_bp.route("/api/backtest/recommendations", methods=["GET"])
+@api_error_handler("get_backtest_recommendations")
 def get_backtest_recommendations():
     """Get historical recommendations for backtesting analysis."""
-    try:
-        symbol = request.args.get("symbol", "").strip().upper()
-        days_back = int(request.args.get("days_back", 30))
-        strategy_type = request.args.get("strategy_type", "").strip().lower()
+    symbol = request.args.get("symbol", "").strip().upper()
+    days_back = int(request.args.get("days_back", 30))
+    strategy_type = request.args.get("strategy_type", "").strip().lower()
 
-        # Use the backtest service
-        result = backtest_service.get_backtest_recommendations(symbol, days_back, strategy_type)
-        
-        return create_api_response(data=result)
+    result = backtest_service.get_backtest_recommendations(symbol, days_back, strategy_type)
 
-    except Exception as e:
-        return handle_api_error(e, "get_backtest_recommendations endpoint")
+    return create_api_response(data=result)
 
 
 @backtest_bp.route("/api/backtest/stats", methods=["GET"])
+@api_error_handler("get_backtest_statistics")
 def get_backtest_statistics():
     """Get comprehensive backtesting statistics from historical recommendations."""
-    try:
-        symbol = request.args.get("symbol", "").strip().upper()
-        days_back = int(request.args.get("days_back", 30))
+    symbol = request.args.get("symbol", "").strip().upper()
+    days_back = int(request.args.get("days_back", 30))
 
-        # Use the backtest service
-        result = backtest_service.get_backtest_statistics(symbol, days_back)
-        
-        return create_api_response(data=result)
+    result = backtest_service.get_backtest_statistics(symbol, days_back)
 
-    except Exception as e:
-        return handle_api_error(e, "get_backtest_statistics endpoint")
+    return create_api_response(data=result)
 
 
 # Helper functions moved to services/backtest_service.py

--- a/src/web/routes/system_routes.py
+++ b/src/web/routes/system_routes.py
@@ -9,11 +9,8 @@ import platform
 import psycopg2.extras
 
 # Import helper functions
-from ..helpers import (
-    create_api_response, 
-    handle_api_error, 
-    api_error_handler
-)
+from ..helpers import create_api_response
+from ..utils import api_error_handler
 
 # Import core modules
 from ...core.database import get_db_connection

--- a/src/web/utils/decorators.py
+++ b/src/web/utils/decorators.py
@@ -24,29 +24,35 @@ def api_error_handler(operation_name: str = None):
         def wrapper(*args, **kwargs):
             start_time = time.time()
             op_name = operation_name or f"{func.__module__}.{func.__name__}"
-            
+            request_path = request.path if request else "unknown"
+
+            trading_logger.api_logger.info(
+                f"Handling request for {op_name} at {request_path}"
+            )
+
             try:
                 result = func(*args, **kwargs)
-                
+
                 # Log successful operations (optional performance tracking)
                 execution_time = time.time() - start_time
                 if execution_time > 1.0:  # Log slow operations
                     trading_logger.api_logger.warning(
-                        f"Slow operation {op_name}: {execution_time:.3f}s"
+                        f"Slow operation {op_name} at {request_path}: {execution_time:.3f}s"
                     )
-                
+
                 return result
-                
+
             except Exception as e:
                 execution_time = time.time() - start_time
                 trading_logger.error_logger.error(
-                    f"Error in {op_name} after {execution_time:.3f}s: {str(e)}"
+                    f"Error in {op_name} at {request_path} after {execution_time:.3f}s: {str(e)}"
                 )
-                log_exception(f"Error in {op_name}", e)
-                
+                log_exception(f"Error in {op_name} at {request_path}", e)
+
                 # Create error response directly to avoid circular import
                 from .formatters import format_error_response
                 response = format_error_response(str(e))
+                response["path"] = request_path
                 return jsonify(response), 500
         
         return wrapper


### PR DESCRIPTION
## Summary
- add path-aware api error handler
- wrap analysis and backtest endpoints with api error handler

## Testing
- `pytest` *(fails: No module named 'src.core.config')*

------
https://chatgpt.com/codex/tasks/task_e_68c46e18844c832aa3b29fa467455ca2