### PR TITLE
refactor: centralize API error handling

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -27,7 +27,8 @@ from src.trading.trading_strategy import TradingStrategy
 from src.core.market_manager import MarketManager
 from src.core.watchlist_manager import watchlist_manager
 # Import helper functions
-from .helpers import create_api_response, handle_api_error
+from .helpers import create_api_response
+from .utils import handle_api_error
 # Import and register route blueprints
 from .routes import register_routes
 

--- a/src/web/helpers.py
+++ b/src/web/helpers.py
@@ -5,12 +5,12 @@ Helper functions for the Flask web application - optimized with utilities
 
 from flask import jsonify, request
 from datetime import datetime
-from functools import wraps
 from typing import Tuple, List, Dict, Any
 
 # Import optimized utilities
 from .utils.formatters import format_api_response, format_error_response
 from .utils.validators import validate_symbol as validate_symbol_util
+from .utils.error_handler import handle_api_error
 from .repositories import market_data_repo
 from ..core.logger import log_exception
 
@@ -37,18 +37,6 @@ def create_api_response(data=None, success=True, message="", error_code=None,
 
     response = format_api_response(data, message)
     return jsonify(response), status_code
-
-
-def handle_api_error(e, context="API operation"):
-    """Standardized error handling for API endpoints"""
-    log_exception(f"Error in {context}", e)
-    return create_api_response(
-        success=False,
-        error=str(e),
-        status_code=500,
-        path=request.path,
-        method=request.method
-    )
 
 
 def get_request_params(required_params=None, optional_params=None):
@@ -112,16 +100,3 @@ def get_preloaded_opportunities(opportunity_type=None):
     except Exception as e:
         log_exception("Error getting preloaded opportunities", e)
         return [], None
-
-
-def api_error_handler(context="API operation"):
-    """Decorator for standardized API error handling"""
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except Exception as e:
-                return handle_api_error(e, context)
-        return wrapper
-    return decorator

--- a/src/web/routes/logging_routes.py
+++ b/src/web/routes/logging_routes.py
@@ -2,7 +2,8 @@ from flask import Blueprint, request
 from datetime import datetime
 import json
 
-from ..helpers import create_api_response, handle_api_error
+from ..helpers import create_api_response
+from ..utils import handle_api_error
 from ..utils.page_logger import page_logger
 
 logging_bp = Blueprint("logging", __name__)

--- a/src/web/routes/page_routes.py
+++ b/src/web/routes/page_routes.py
@@ -5,8 +5,6 @@ Page routes for HTML template rendering
 from flask import Blueprint, render_template, request
 from datetime import datetime
 
-# Import helper functions
-from ..helpers import create_api_response, handle_api_error
 from ...core.database import get_db_connection
 
 # Create blueprint

--- a/src/web/routes/system_routes.py
+++ b/src/web/routes/system_routes.py
@@ -10,7 +10,7 @@ import psycopg2.extras
 
 # Import helper functions
 from ..helpers import create_api_response
-from ..utils import api_error_handler
+from ..utils import api_error_handler, handle_api_error
 
 # Import core modules
 from ...core.database import get_db_connection

--- a/src/web/routes/telegram_routes.py
+++ b/src/web/routes/telegram_routes.py
@@ -7,10 +7,9 @@ from datetime import datetime
 
 # Import helper functions
 from ..helpers import (
-    create_api_response, 
-    handle_api_error, 
-    api_error_handler
+    create_api_response
 )
+from ..utils import handle_api_error
 
 # Import core modules
 from ...core.logger import trading_logger, log_exception

--- a/src/web/utils/__init__.py
+++ b/src/web/utils/__init__.py
@@ -2,9 +2,12 @@
 Utilities module for common functionality
 """
 
+from .error_handler import (
+    api_error_handler,
+    handle_api_error
+)
 from .decorators import (
-    api_error_handler, 
-    cache_response, 
+    cache_response,
     validate_request,
     timing_decorator,
     log_request
@@ -28,7 +31,8 @@ from .formatters import (
 __all__ = [
     # Decorators
     'api_error_handler',
-    'cache_response', 
+    'handle_api_error',
+    'cache_response',
     'validate_request',
     'timing_decorator',
     'log_request',

--- a/src/web/utils/decorators.py
+++ b/src/web/utils/decorators.py
@@ -8,55 +8,8 @@ from datetime import datetime
 from typing import Callable, Any, Dict, Optional
 from flask import request, jsonify
 
-from ...core.logger import trading_logger, log_exception
+from ...core.logger import trading_logger
 from ...core.cache import get_cached_result, cache_result
-
-
-def api_error_handler(operation_name: str = None):
-    """
-    Optimized decorator for consistent API error handling with performance tracking
-    
-    Args:
-        operation_name: Optional operation name for logging
-    """
-    def decorator(func: Callable) -> Callable:
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            start_time = time.time()
-            op_name = operation_name or f"{func.__module__}.{func.__name__}"
-            request_path = request.path if request else "unknown"
-
-            trading_logger.api_logger.info(
-                f"Handling request for {op_name} at {request_path}"
-            )
-
-            try:
-                result = func(*args, **kwargs)
-
-                # Log successful operations (optional performance tracking)
-                execution_time = time.time() - start_time
-                if execution_time > 1.0:  # Log slow operations
-                    trading_logger.api_logger.warning(
-                        f"Slow operation {op_name} at {request_path}: {execution_time:.3f}s"
-                    )
-
-                return result
-
-            except Exception as e:
-                execution_time = time.time() - start_time
-                trading_logger.error_logger.error(
-                    f"Error in {op_name} at {request_path} after {execution_time:.3f}s: {str(e)}"
-                )
-                log_exception(f"Error in {op_name} at {request_path}", e)
-
-                # Create error response directly to avoid circular import
-                from .formatters import format_error_response
-                response = format_error_response(str(e))
-                response["path"] = request_path
-                return jsonify(response), 500
-        
-        return wrapper
-    return decorator
 
 
 def cache_response(cache_key_prefix: str = None, timeout: int = 300, 

--- a/src/web/utils/error_handler.py
+++ b/src/web/utils/error_handler.py
@@ -1,0 +1,47 @@
+import time
+from functools import wraps
+from typing import Callable
+from flask import request, jsonify
+
+from ...core.logger import trading_logger, log_exception
+from .formatters import format_error_response
+
+
+def handle_api_error(e: Exception, context: str = "API operation"):
+    """Centralized error handler that logs and formats API errors."""
+    log_exception(f"Error in {context}", e)
+    path = request.path if request else None
+    method = request.method if request else None
+    response = format_error_response(str(e), path=path, method=method)
+    return jsonify(response), 500
+
+
+def api_error_handler(operation_name: str = None):
+    """Decorator for consistent API error handling with performance tracking."""
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+            op_name = operation_name or f"{func.__module__}.{func.__name__}"
+            request_path = request.path if request else "unknown"
+
+            trading_logger.api_logger.info(
+                f"Handling request for {op_name} at {request_path}"
+            )
+
+            try:
+                result = func(*args, **kwargs)
+                execution_time = time.time() - start_time
+                if execution_time > 1.0:
+                    trading_logger.api_logger.warning(
+                        f"Slow operation {op_name} at {request_path}: {execution_time:.3f}s"
+                    )
+                return result
+            except Exception as e:
+                execution_time = time.time() - start_time
+                trading_logger.error_logger.error(
+                    f"Error in {op_name} at {request_path} after {execution_time:.3f}s: {str(e)}"
+                )
+                return handle_api_error(e, op_name)
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Summary
- consolidate API error handling in new `error_handler` utility
- remove redundant handlers from `helpers` and update route imports
- expose unified error handler via `web.utils`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.core.config')*

------
https://chatgpt.com/codex/tasks/task_e_68c4748f11c0832ab1899fb48d7ad7ab