### PR TITLE
refactor: centralize API error handling and unify logging

### DIFF
--- a/src/core/database.py
+++ b/src/core/database.py
@@ -6,14 +6,12 @@ Provides connection handling for PostgreSQL database.
 
 import psycopg2
 import psycopg2.extras
-import logging
 from contextlib import contextmanager
 from .config import Config
 from typing import Dict, Any, Optional
 import json
 import numpy as np
-
-logger = logging.getLogger(__name__)
+from .logger import trading_logger as logger
 
 
 def convert_numpy_values(value):

--- a/src/core/db_utils.py
+++ b/src/core/db_utils.py
@@ -6,11 +6,8 @@ import psycopg2
 from psycopg2 import pool
 from contextlib import contextmanager
 from typing import Optional, Iterator, Any, Dict
-import logging
 from src.core.config import Config
 from src.core.logger import log_error, log_info
-
-logger = logging.getLogger(__name__)
 
 class DatabaseConnectionError(Exception):
     """Custom exception for database connection issues"""

--- a/src/core/market_manager.py
+++ b/src/core/market_manager.py
@@ -1,13 +1,10 @@
 """
 Market Manager - Centralized management of foreign exchanges and markets
 """
-import logging
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple
 from src.core.db_utils import execute_query
 from src.core.logger import log_info, log_error, log_debug
-
-logger = logging.getLogger(__name__)
 
 class MarketManager:
     """Manages foreign exchange and market information"""

--- a/src/core/recommendation_manager.py
+++ b/src/core/recommendation_manager.py
@@ -17,15 +17,13 @@ Any changes here affect ALL trading recommendations across the entire
 application.
 """
 
-import logging
 from datetime import datetime, timedelta
 from typing import Dict, List
 from contextlib import contextmanager
 import numpy as np
 import psycopg2.extras
 from src.core.database import get_db_connection
-
-logger = logging.getLogger(__name__)
+from .logger import trading_logger as logger
 
 
 def convert_numpy_values(value):

--- a/src/core/scalping_analyzer.py
+++ b/src/core/scalping_analyzer.py
@@ -10,15 +10,12 @@ from datetime import datetime, date
 from typing import Dict, List, Any
 import json
 import time
-import logging
 
 from .database import execute_query
 from .config import Config
 from .logger import log_info, log_error, log_warning, log_debug
 from .sentiment_analyzer import SentimentAnalyzer
 from ..data.data_fetcher import DataFetcher
-
-logger = logging.getLogger(__name__)
 
 
 class ScalpingAnalyzer:

--- a/src/data/historical_data_updater.py
+++ b/src/data/historical_data_updater.py
@@ -6,7 +6,6 @@ This module handles updating 2-year historical data for stocks and crypto
 to ensure Enhanced Analysis has fresh data for backtesting.
 """
 
-import logging
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional
 import pandas as pd
@@ -14,9 +13,10 @@ import time
 
 from ..core.config import Config
 from ..core.database import get_db_connection
+from ..core.logger import trading_logger
 from .data_fetcher import DataFetcher
 
-logger = logging.getLogger(__name__)
+logger = trading_logger
 
 
 class HistoricalDataUpdater:

--- a/src/data/preload_news_opportunities.py
+++ b/src/data/preload_news_opportunities.py
@@ -1,12 +1,12 @@
-import logging
 from datetime import datetime
 from src.data.news_monitor import NewsMonitor
 from src.core.database import get_db_connection
 from psycopg2.extras import Json
+from src.core.logger import trading_logger
 
 NEWS_OPPORTUNITIES_TABLE = "preloaded_news_opportunities"
 
-logger = logging.getLogger(__name__)
+logger = trading_logger
 
 def ensure_news_opportunities_table():
     """

--- a/src/data/preload_watchlist_opportunities.py
+++ b/src/data/preload_watchlist_opportunities.py
@@ -8,7 +8,6 @@ to the database for fast retrieval. The opportunities are calculated early each
 trading day and stored for quick access.
 """
 
-import logging
 import sys
 import json
 import traceback
@@ -26,10 +25,11 @@ from src.core.batch_processor import (
     create_watchlist_tasks,
 )
 from psycopg2.extras import Json
+from src.core.logger import trading_logger
 
 WATCHLIST_OPPORTUNITIES_TABLE = "preloaded_watchlist_opportunities"
 
-logger = logging.getLogger(__name__)
+logger = trading_logger
 
 def ensure_watchlist_opportunities_table():
     """

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -27,7 +27,8 @@ from src.trading.trading_strategy import TradingStrategy
 from src.core.market_manager import MarketManager
 from src.core.watchlist_manager import watchlist_manager
 # Import helper functions
-from .helpers import create_api_response, handle_api_error
+from .helpers import create_api_response
+from .utils import handle_api_error
 # Import and register route blueprints
 from .routes import register_routes
 

--- a/src/web/helpers.py
+++ b/src/web/helpers.py
@@ -5,12 +5,12 @@ Helper functions for the Flask web application - optimized with utilities
 
 from flask import jsonify, request
 from datetime import datetime
-from functools import wraps
 from typing import Tuple, List, Dict, Any
 
 # Import optimized utilities
 from .utils.formatters import format_api_response, format_error_response
 from .utils.validators import validate_symbol as validate_symbol_util
+from .utils.error_handler import handle_api_error
 from .repositories import market_data_repo
 from ..core.logger import log_exception
 
@@ -37,18 +37,6 @@ def create_api_response(data=None, success=True, message="", error_code=None,
 
     response = format_api_response(data, message)
     return jsonify(response), status_code
-
-
-def handle_api_error(e, context="API operation"):
-    """Standardized error handling for API endpoints"""
-    log_exception(f"Error in {context}", e)
-    return create_api_response(
-        success=False,
-        error=str(e),
-        status_code=500,
-        path=request.path,
-        method=request.method
-    )
 
 
 def get_request_params(required_params=None, optional_params=None):
@@ -112,16 +100,3 @@ def get_preloaded_opportunities(opportunity_type=None):
     except Exception as e:
         log_exception("Error getting preloaded opportunities", e)
         return [], None
-
-
-def api_error_handler(context="API operation"):
-    """Decorator for standardized API error handling"""
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except Exception as e:
-                return handle_api_error(e, context)
-        return wrapper
-    return decorator

--- a/src/web/routes/logging_routes.py
+++ b/src/web/routes/logging_routes.py
@@ -2,7 +2,8 @@ from flask import Blueprint, request
 from datetime import datetime
 import json
 
-from ..helpers import create_api_response, handle_api_error
+from ..helpers import create_api_response
+from ..utils import handle_api_error
 from ..utils.page_logger import page_logger
 
 logging_bp = Blueprint("logging", __name__)

--- a/src/web/routes/page_routes.py
+++ b/src/web/routes/page_routes.py
@@ -5,8 +5,6 @@ Page routes for HTML template rendering
 from flask import Blueprint, render_template, request
 from datetime import datetime
 
-# Import helper functions
-from ..helpers import create_api_response, handle_api_error
 from ...core.database import get_db_connection
 
 # Create blueprint

--- a/src/web/routes/system_routes.py
+++ b/src/web/routes/system_routes.py
@@ -10,7 +10,7 @@ import psycopg2.extras
 
 # Import helper functions
 from ..helpers import create_api_response
-from ..utils import api_error_handler
+from ..utils import api_error_handler, handle_api_error
 
 # Import core modules
 from ...core.database import get_db_connection

--- a/src/web/routes/telegram_routes.py
+++ b/src/web/routes/telegram_routes.py
@@ -7,10 +7,9 @@ from datetime import datetime
 
 # Import helper functions
 from ..helpers import (
-    create_api_response, 
-    handle_api_error, 
-    api_error_handler
+    create_api_response
 )
+from ..utils import handle_api_error
 
 # Import core modules
 from ...core.logger import trading_logger, log_exception

--- a/src/web/utils/__init__.py
+++ b/src/web/utils/__init__.py
@@ -2,9 +2,12 @@
 Utilities module for common functionality
 """
 
+from .error_handler import (
+    api_error_handler,
+    handle_api_error
+)
 from .decorators import (
-    api_error_handler, 
-    cache_response, 
+    cache_response,
     validate_request,
     timing_decorator,
     log_request
@@ -28,7 +31,8 @@ from .formatters import (
 __all__ = [
     # Decorators
     'api_error_handler',
-    'cache_response', 
+    'handle_api_error',
+    'cache_response',
     'validate_request',
     'timing_decorator',
     'log_request',

--- a/src/web/utils/decorators.py
+++ b/src/web/utils/decorators.py
@@ -8,55 +8,8 @@ from datetime import datetime
 from typing import Callable, Any, Dict, Optional
 from flask import request, jsonify
 
-from ...core.logger import trading_logger, log_exception
+from ...core.logger import trading_logger
 from ...core.cache import get_cached_result, cache_result
-
-
-def api_error_handler(operation_name: str = None):
-    """
-    Optimized decorator for consistent API error handling with performance tracking
-    
-    Args:
-        operation_name: Optional operation name for logging
-    """
-    def decorator(func: Callable) -> Callable:
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            start_time = time.time()
-            op_name = operation_name or f"{func.__module__}.{func.__name__}"
-            request_path = request.path if request else "unknown"
-
-            trading_logger.api_logger.info(
-                f"Handling request for {op_name} at {request_path}"
-            )
-
-            try:
-                result = func(*args, **kwargs)
-
-                # Log successful operations (optional performance tracking)
-                execution_time = time.time() - start_time
-                if execution_time > 1.0:  # Log slow operations
-                    trading_logger.api_logger.warning(
-                        f"Slow operation {op_name} at {request_path}: {execution_time:.3f}s"
-                    )
-
-                return result
-
-            except Exception as e:
-                execution_time = time.time() - start_time
-                trading_logger.error_logger.error(
-                    f"Error in {op_name} at {request_path} after {execution_time:.3f}s: {str(e)}"
-                )
-                log_exception(f"Error in {op_name} at {request_path}", e)
-
-                # Create error response directly to avoid circular import
-                from .formatters import format_error_response
-                response = format_error_response(str(e))
-                response["path"] = request_path
-                return jsonify(response), 500
-        
-        return wrapper
-    return decorator
 
 
 def cache_response(cache_key_prefix: str = None, timeout: int = 300, 

--- a/src/web/utils/error_handler.py
+++ b/src/web/utils/error_handler.py
@@ -1,0 +1,47 @@
+import time
+from functools import wraps
+from typing import Callable
+from flask import request, jsonify
+
+from ...core.logger import trading_logger, log_exception
+from .formatters import format_error_response
+
+
+def handle_api_error(e: Exception, context: str = "API operation"):
+    """Centralized error handler that logs and formats API errors."""
+    log_exception(f"Error in {context}", e)
+    path = request.path if request else None
+    method = request.method if request else None
+    response = format_error_response(str(e), path=path, method=method)
+    return jsonify(response), 500
+
+
+def api_error_handler(operation_name: str = None):
+    """Decorator for consistent API error handling with performance tracking."""
+    def decorator(func: Callable) -> Callable:
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+            op_name = operation_name or f"{func.__module__}.{func.__name__}"
+            request_path = request.path if request else "unknown"
+
+            trading_logger.api_logger.info(
+                f"Handling request for {op_name} at {request_path}"
+            )
+
+            try:
+                result = func(*args, **kwargs)
+                execution_time = time.time() - start_time
+                if execution_time > 1.0:
+                    trading_logger.api_logger.warning(
+                        f"Slow operation {op_name} at {request_path}: {execution_time:.3f}s"
+                    )
+                return result
+            except Exception as e:
+                execution_time = time.time() - start_time
+                trading_logger.error_logger.error(
+                    f"Error in {op_name} at {request_path} after {execution_time:.3f}s: {str(e)}"
+                )
+                return handle_api_error(e, op_name)
+        return wrapper
+    return decorator


### PR DESCRIPTION
## Summary
- consolidate API error handling in new `error_handler` utility
- remove redundant handlers from helpers and update route imports
- expose unified error handler via `web.utils`
- standardize logging by routing core/data modules through shared `trading_logger`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.core.config')*


------
https://chatgpt.com/codex/tasks/task_e_68c4748f11c0832ab1899fb48d7ad7ab