### PR TITLE
feat: allow full-width layout for scalping signals

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -28,9 +28,11 @@
     {% include 'navbar.html' %}
 
     <!-- Main Content -->
+    {% block layout_container %}
     <div class="container mt-4">
         {% block content %}{% endblock %}
     </div>
+    {% endblock %}
 
     <!-- Footer -->
     <footer class="footer mt-5 py-4">

--- a/src/web/templates/scalping_signals.html
+++ b/src/web/templates/scalping_signals.html
@@ -2,11 +2,15 @@
 
 {% block title %}Scalping Signals - Trading AI{% endblock %}
 
+{% block layout_container %}
+<div class="container-fluid" id="scalpingSignalsContainer">
+    {{ self.content() }}
+</div>
+{% endblock %}
+
 {% block content %}
     <link rel="stylesheet" href="{{ url_for('static', filename='css/scalping_signals.css') }}">
-</head>
-<body>
-    <div class="container-fluid" id="scalpingSignalsContainer">
+    
         <!-- Header -->
         <div class="row bg-primary text-white p-3 mb-4">
             <div class="col">
@@ -216,12 +220,11 @@
         <div class="row" id="noDataMessage" style="display: none;">
             <div class="col text-center">
                 <div class="alert alert-info">
-                    <i class="fas fa-info-circle"></i> No scalping opportunities found. 
+                    <i class="fas fa-info-circle"></i> No scalping opportunities found.
                     Click "Run Analysis" to scan for new opportunities.
                 </div>
             </div>
         </div>
-    </div>
 
     <!-- Floating Refresh Button -->
     <button class="btn btn-primary btn-lg refresh-btn" onclick="refreshData()" title="Refresh Data">


### PR DESCRIPTION
## Summary
- wrap base template container in `layout_container` block to allow overrides
- switch scalping signals template to a top-level `container-fluid`

## Testing
- `pytest tests/unit/test_config.py -q` *(fails: ModuleNotFoundError: No module named 'core.config')*


------
https://chatgpt.com/codex/tasks/task_e_68c4cab96568832aab8567ed96ead1ad