### PR TITLE
Initialize frontend logger earlier

### DIFF
--- a/src/web/static/js/logger.js
+++ b/src/web/static/js/logger.js
@@ -236,48 +236,43 @@ FrontendLogger.prototype = {
     }
 };
 
-// Create global logger instance
-var frontendLogger;
+// Create global logger instance immediately
+try {
+    // Create logger and expose globally
+    window.frontendLogger = new FrontendLogger();
+    var frontendLogger = window.frontendLogger;
 
-// Initialize logger when DOM is loaded
-document.addEventListener('DOMContentLoaded', function() {
-    try {
-        // Create logger instance
-        frontendLogger = new FrontendLogger();
-        
-        // Make it available globally
-        window.frontendLogger = frontendLogger;
-        
-        // Log that logger is initialized
-        frontendLogger.info('Logger initialized', 'system');
-        
-        // Log page load event
+    // Log that logger is initialized
+    frontendLogger.info('Logger initialized', 'system');
+
+    // Log DOM ready event
+    document.addEventListener('DOMContentLoaded', function() {
         frontendLogger.info('DOM Content Loaded', 'system');
-        
-        // Set up window load event
-        window.addEventListener('load', function() {
-            frontendLogger.info('Page fully loaded', 'system');
-        });
-        
-        // Set up beforeunload event
-        window.addEventListener('beforeunload', function() {
-            frontendLogger.info('Page unloading', 'system');
-        });
-        
-        // Set up visibility change events
-        document.addEventListener('visibilitychange', function() {
-            if (document.hidden) {
-                frontendLogger.info('Page hidden', 'system');
-            } else {
-                frontendLogger.info('Page visible', 'system');
-            }
-        });
-        
-    } catch (e) {
-        // Fallback error handling if logger fails to initialize
-        console.error('Failed to initialize logger:', e);
-    }
-});
+    });
+
+    // Set up window load event
+    window.addEventListener('load', function() {
+        frontendLogger.info('Page fully loaded', 'system');
+    });
+
+    // Set up beforeunload event
+    window.addEventListener('beforeunload', function() {
+        frontendLogger.info('Page unloading', 'system');
+    });
+
+    // Set up visibility change events
+    document.addEventListener('visibilitychange', function() {
+        if (document.hidden) {
+            frontendLogger.info('Page hidden', 'system');
+        } else {
+            frontendLogger.info('Page visible', 'system');
+        }
+    });
+
+} catch (e) {
+    // Fallback error handling if logger fails to initialize
+    console.error('Failed to initialize logger:', e);
+}
 
 // Export for Node.js/CommonJS if needed
 if (typeof module !== 'undefined' && module.exports) {

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -22,6 +22,10 @@
     
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+
+    <!-- Frontend Logger -->
+    <script src="{{ url_for('static', filename='js/logger.js') }}"></script>
+    {% block extra_head %}{% endblock %}
 </head>
 <body>
     <!-- Include Navigation -->
@@ -56,10 +60,7 @@
     
     <!-- Socket.IO for real-time updates -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.7.2/socket.io.js"></script>
-    
-    <!-- Frontend Logger (MUST BE FIRST) -->
-    <script src="{{ url_for('static', filename='js/logger.js') }}"></script>
-    
+
     <!-- Base JavaScript Functions -->
     <script src="{{ url_for('static', filename='js/base.js') }}"></script>
 

--- a/src/web/templates/scalping_signals.html
+++ b/src/web/templates/scalping_signals.html
@@ -2,6 +2,17 @@
 
 {% block title %}Scalping Signals - Trading AI{% endblock %}
 
+{% block extra_head %}
+<script>
+  window.addEventListener('error', e =>
+    (window.frontendLogger || console).error('Early JS error: ' + e.message)
+  );
+  window.addEventListener('unhandledrejection', e =>
+    (window.frontendLogger || console).error('Unhandled rejection: ' + e.reason)
+  );
+</script>
+{% endblock %}
+
 {% block content %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/scalping_signals.css') }}">
 
@@ -264,7 +275,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="/static/js/logger.js"></script>
 <script>
         let currentFilter = 'all';
         let opportunitiesData = [];
@@ -273,37 +283,9 @@
         // Initialize page
         document.addEventListener('DOMContentLoaded', function() {
             try {
-                alert('DOMContentLoaded fired - JavaScript is running');
-                // Wait for frontendLogger to be available
-                if (typeof frontendLogger === 'undefined') {
-                    console.error('frontendLogger not available, retrying in 100ms');
-                    alert('frontendLogger not available, retrying in 100ms');
-                    setTimeout(() => {
-                        try {
-                            if (typeof frontendLogger !== 'undefined') {
-                                alert('frontendLogger available after retry, calling initializePage');
-                                initializePage();
-                            } else {
-                                console.error('frontendLogger still not available after retry');
-                                alert('frontendLogger still not available after retry, initializing without logging');
-                                // Initialize without logging
-                                loadStats();
-                                loadOpportunities();
-                                setupFilterButtons();
-                                setupAutoRefreshToggle();
-                            }
-                        } catch (error) {
-                            console.error('Error in frontendLogger retry:', error);
-                            alert('Error in frontendLogger retry: ' + error.message);
-                        }
-                    }, 100);
-                } else {
-                    alert('frontendLogger available immediately, calling initializePage');
-                    initializePage();
-                }
+                initializePage();
             } catch (error) {
-                console.error('Error in DOMContentLoaded:', error);
-                alert('Error in DOMContentLoaded: ' + error.message);
+                (window.frontendLogger || console).error('Error in DOMContentLoaded: ' + error.message);
             }
         });
 
@@ -316,7 +298,6 @@
                 setupAutoRefreshToggle();
             } catch (error) {
                 frontendLogger.error('Error in initializePage: ' + error.message, 'scalping');
-                console.error('Error in initializePage:', error);
             }
         }
 


### PR DESCRIPTION
## Summary
- Instantiate `FrontendLogger` as soon as the script loads and set up window lifecycle logging outside of `DOMContentLoaded`.
- Load `logger.js` from the document head and add early error/rejection handlers for scalping signals page.
- Simplify scalping signals script initialization now that the logger is always available.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src.core.config'; No module named 'playwright'; etc.)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e125a7b8832ab22af816888cecec