### PR TITLE
docs: unify app refactor and service split plan

### DIFF
--- a/00_app_refactor.md
+++ b/00_app_refactor.md
@@ -1,207 +1,131 @@
-# App.py Refactoring Plan - Performance-Focused Edition (Updated)
+# App Refactoring & Service Split Plan (Unified)
 
-## Overview
+## 1. Goals
+- Detangle the monolithic `app.py` (5k+ lines) into modular blueprints, services, and repositories.
+- Extract proprietary algorithms, DB access, and third‑party integrations into a private **core-service**.
+- Leave only templates, static assets, and thin Flask routes in a public **app-ui** repo that talks to the core via HTTP.
+- Maintain existing functionality with minimal downtime while improving performance and testability.
 
-The current `app.py` (5,069 lines) mixes routing, business logic, and data access. The goal is to decompose it into modular, testable units with attention to runtime efficiency and maintainability. This plan focuses strictly on structure and performance.
+## 2. Current State Mapping
+- **Proprietary modules**
+  - `src/core` – DB layer, caching, watchlist, telegram, etc.
+  - `src/data` – `DataFetcher` and external market/news APIs.
+  - `src/trading` – `trading_strategy.py`, `enhanced_trading_strategy.py` and related logic.
+  - `src/utils` – DB/job setup scripts.
+- **UI modules (mixed with core today)**
+  - `src/web/app.py` and `src/web/routes/*` – routes import core classes, perform SQL queries, and call external APIs.
+  - `src/web/helpers.py`, `src/web/repositories` – direct DB access.
+  - Templates & static files under `src/web/templates` and `src/web/static`.
+- **Pain points**
+  - 54 routes still live in `app.py` with business logic and DB calls.
+  - Tight coupling makes unit testing and performance tuning difficult.
 
-**Current Status:** Significant refactoring progress made - major routes moved to blueprints, but substantial work remains.
+## 3. Target Architecture
+```
+core-service (private)
+ ├─ src/core, src/data, src/trading, src/utils
+ ├─ REST API layer exposing analysis/backtest endpoints
+ └─ owns DB schema, API keys, caching, background jobs
 
-## Key Issues
-- Monolithic file with mixed concerns (partially addressed)
-- Duplicate/inefficient database access patterns
-- Synchronous long-running operations blocking requests
-- Inconsistent caching implementation; repeated expensive computations
-- Difficult to test due to global state and tight coupling
-- Missing dependencies causing test failures (lxml, xml parser)
+app-ui (shared)
+ ├─ templates, static assets, JS/CSS
+ ├─ thin Flask blueprints + `core_client`
+ └─ no direct DB/API access
 
-## Current State Assessment
+(optional) app-api
+ └─ small public CRUD service if needed
+```
 
-### ✅ Already Completed:
-- Comprehensive blueprint structure exists in `src/web/routes/`:
-  - `analysis_routes.py` - Analysis endpoints (sp500_analysis, crypto_analysis, analyze_stock, enhanced_analysis)
-  - `backtest_routes.py` - Backtesting functionality (backtest, historical backtest, stats)
-  - `system_routes.py` - System monitoring (system_status, logs, performance_status, news_services)
-  - `telegram_routes.py` - Telegram integration (test, toggle, send messages, chat management)
-  - `page_routes.py` - HTML template rendering (all main pages)
-  - `logging_routes.py` - Client-side logging endpoints
-- Services layer framework exists (`analysis_service`, `backtest_service`)
-- Helper functions centralized in `helpers.py`
-- Route registration system implemented in `routes/__init__.py`
+## 4. Interface Contract (OpenAPI outline)
+```yaml
+paths:
+  /analysis/stock:        {post: {symbol}}
+  /analysis/bulk:         {post: {symbols[]}}
+  /analysis/sp500:       {get: {limit?, refresh?}}
+  /analysis/crypto:      {get: {refresh?}}
+  /analysis/enhanced:    {post: {symbol}}
+  /scalping/opportunities: {get: {}}
+  /backtest/run:         {post: {symbol, days_back, initial_capital}}
+  /backtest/recommendations: {get: {symbol?, days_back?}}
+  /system/status:        {get: {}}
+  /watchlist/{symbol}:   {get|post|delete}
+```
+Responses are JSON with `{error: string}` on failure.
 
-### ❌ Still Needs Work:
-- Major routes still in main `app.py` (54 routes remaining):
-  - `/api/dashboard/data` (lines 70-200)
-  - `/api/market_movers` (lines 241-359) 
-  - `/api/portfolio` (lines 1572-1691)
-  - `/api/foreign_markets/overview` (lines 1913-2133)
-  - `/api/news_opportunities` (lines 2419-2501)
-  - `/api/watchlist_opportunities` (lines 2501-2735)
-  - `/api/recommendations` (lines 4294-4374)
-  - And 47+ other routes
-- Business logic mixed in route handlers
-- Inconsistent service layer usage
-- Missing dependencies causing test failures
+## 5. Auth & Security Basics
+- Short‑lived Bearer or HMAC tokens issued by core-service; UI sends `Authorization` header.
+- CORS: core-service only allows UI domain(s); block wildcard.
+- Basic IP/token rate limiting and request/response logging.
+- Secrets via environment variables (`.env`, not committed); none in client JS.
 
-## Refactoring Phases (Updated)
+## 6. Refactoring & Migration Phases
+| Phase | Focus | Key Actions |
+|-------|-------|-------------|
+|0. Inventory|Tag files as UI vs Core|Identify modules to move; mark remaining 54 routes in `app.py`|
+|1. Route Modularization (Week 1‑2)|Finish moving routes out of `app.py`|Relocate dashboard, market_movers, portfolio, foreign markets, news, watchlist, recommendations, and remaining 47+ routes into blueprints; update `routes/__init__.py`|
+|2. Service Layer Completion (Week 2‑3)|Isolate business logic|Finalize `analysis_service.py`, create `dashboard_service`, `market_service`, `portfolio_service`, `news_service`, `recommendation_service`; introduce dependency injection|
+|3. Core Extraction & HTTP Client (Week 3‑4)|Split repo and expose REST endpoints|Move proprietary modules to new `core-service`; implement API layer; add `core_client` in UI; replace direct imports and DB calls with HTTP requests|
+|4. Data Layer Optimization (Week 4)|Connection pooling, repositories, caching|Implement `DatabaseConnector`, standardize repositories, add Redis/TTL caching, eliminate duplicate queries|
+|5. Performance Enhancements (Week 4‑5)|Async & batching|Move long I/O tasks to background jobs, optimize SP500 analysis, batch queries, add in-memory caches|
+|6. Testing & Observability (Week 5‑6)|Quality and monitoring|Unit tests for services/repos, integration tests hitting core API, logging & timing metrics, fix missing deps (`lxml`, XML parser)|
+|7. Cutover & Cleanup (Week 6)|Flip feature flags, retire legacy code|Remove remaining proprietary logic from UI repo, finalize OpenAPI spec and docs|
 
-### Phase 1: Complete Route Modularization (Week 1-2)
-**Priority: HIGH** - Finish moving remaining routes from `app.py`
+## 7. Repo Layout & Key Files
+`core-service/`
+```
+src/
+  core/        # DB access, caching, logger, watchlist, telegram
+  data/        # DataFetcher, news/historical jobs
+  trading/     # Strategies and algorithms
+  api/         # REST endpoints (analysis, backtest, scalping…)
+  utils/       # job scheduler, postgres setup
+tests/
+openapi.yaml
+.env.example    # DB_URL, API keys, token secret
+docker-compose.yml
+```
 
-**Immediate Actions:**
-- Move `/api/dashboard/data` → `system_routes.py` (already moved to analysis_routes.py)
-- Move `/api/market_movers` → `analysis_routes.py`
-- Move `/api/portfolio` → `system_routes.py`
-- Move `/api/foreign_markets/overview` → `system_routes.py`
-- Move `/api/news_opportunities` → `analysis_routes.py`
-- Move `/api/watchlist_opportunities` → `analysis_routes.py`
-- Move `/api/recommendations` → `analysis_routes.py`
-- Move remaining 47+ routes to appropriate blueprints
-- Introduce dependency injection for services and database connections
-- Update route registrations in `__init__.py`
+`app-ui/`
+```
+src/web/
+  routes/      # thin blueprints calling core_client
+  templates/   # HTML/Jinja templates
+  static/      # JS/CSS assets
+  core_client/ # wrapper around core-service REST API
+tests/
+openapi.yaml    # paths used by UI
+.env.example    # CORE_BASE_URL, UI token, etc.
+docker-compose.yml
+```
 
-**Target:** Reduce `app.py` from 5,069 lines to ~2,000-2,500 lines
+## 8. Local & Staging Workflows
+- **Local**: `docker-compose` can run UI + mock core for consultants. Swap in private core image by changing `CORE_BASE_URL`.
+- **Staging**: UI points to remote core over HTTPS with short-lived tokens. CORS allows only staging UI domain. Use dev proxy to avoid localhost HTTPS issues.
 
-### Phase 2: Extract Business Logic to Services (Week 2-3)
-**Priority: HIGH** - Complete service layer implementation
+## 9. Data & DB Safety
+- Provide masked/anonymized datasets; remove production keys.
+- Core-service uses least-privilege Postgres role.
+- All DB access lives inside core-service; UI accesses data only via HTTP.
+- Document required env vars in `.env.example`.
 
-**Actions:**
-- Extract business logic from existing route files (not just `app.py`)
-- Fully implement `analysis_service.py` for all analysis operations
-- Create `dashboard_service.py` for dashboard data aggregation
-- Create `market_service.py` for market movers functionality
-- Create `portfolio_service.py` for portfolio management
-- Create `news_service.py` for news opportunities
-- Create `recommendation_service.py` for recommendation engine
-- Ensure functions are small, pure, and testable
-- Replace repetitive code with shared helpers
-- Fix missing dependencies (lxml, xml parser) causing test failures
+## 10. Risks & Effort
+| Risk | Impact | Effort |
+|------|--------|-------|
+|Hidden coupling between UI and core modules|Runtime failures after split|Medium|
+|DB logic or tokens embedded in templates|Security leakage|Small|
+|Increased API call volume via proxy|Potential rate limits|Medium|
+|Consultant requires additional endpoints|Scope creep|Medium‑High|
 
-### Phase 3: Optimize Data Access Layer (Week 3-4)
-**Priority: MEDIUM** - Improve database efficiency
+## 11. Acceptance Criteria
+- `app.py` reduced to <2,500 lines with remaining routes delegated to blueprints and services.
+- UI repo contains only templates/static assets and thin Flask glue; no proprietary logic or DB/API access.
+- Core-service exposes documented endpoints (`openapi.yaml`) and passes unit/integration tests.
+- UI operates solely through `core_client`; feature flags allow gradual cutover.
+- Secrets managed via env vars; CI pipelines green for both repos.
+- Consultant can develop UI independently using mock or staged core-service.
 
-**Actions:**
-- Implement a `DatabaseConnector` with connection pooling
-- Introduce repository classes for CRUD operations
-- Standardize caching implementation across all endpoints
-- Add optional Redis caching for heavy read endpoints
-- Eliminate duplicate database queries (especially in market_movers)
-
-### Phase 4: Performance Enhancements (Week 4-5)
-**Priority: MEDIUM** - Optimize critical paths
-
-**Actions:**
-- Introduce async/await or background jobs for long I/O operations
-- Optimize SP500 analysis endpoint (currently very slow)
-- Batch or vectorize queries for data analysis routines
-- Profile critical paths and optimize bottlenecks
-- Implement lightweight in-memory cache for repeated calculations
-
-### Phase 5: Testing & Observability (Week 5-6)
-**Priority: LOW** - Ensure quality and monitoring
-
-**Actions:**
-- Write unit tests for services and repositories
-- Add integration tests for API routes
-- Include minimal logging and timing metrics to measure improvements
-- Add performance monitoring for critical endpoints
-
-## Expected Outcomes (Revised)
-- `app.py` shrinks from 5,069 lines to **2,000-2,500 lines** (more realistic target)
-- Faster request handling due to caching and async workflows
-- Clear separation of concerns enabling easier maintenance and testing
-- Consistent service layer usage across all endpoints
-- Improved test coverage and reliability
-- Fixed dependency issues causing test failures
-
-## Complexity Assessment (Updated)
-- Route/module extraction: **Medium** (partially complete)
-- Service layer completion: **Medium-High** (framework exists)
-- Data layer and caching: **Medium-High**
-- Async and performance tuning: **High**
-
-Overall complexity: **Medium-High** (unchanged)
-
-## Estimated Performance Gain
-
-*Performance improvement percentages are based on preliminary profiling of current endpoints (using [pytest-benchmark](https://pytest-benchmark.readthedocs.io/en/latest/) and custom timing scripts), as well as published results from similar refactorings in Flask-based applications ([Flask docs: async support](https://flask.palletsprojects.com/en/2.3.x/async-await/)). Actual results may vary depending on workload and deployment environment.*
-
-**Specific Improvements Expected:**
-- Database access latency reduced by ~30% through pooling and caching
-- CPU-bound analysis endpoints up to 40% faster via vectorization
-- SP500 analysis endpoint (currently very slow) - 50-60% improvement expected
-- Market movers endpoint - 25-35% improvement through query optimization
-- Overall request throughput expected to improve by 35–50% on heavy endpoints
-
-## Implementation Priority Matrix
-
-| Phase | Priority | Impact | Effort | Timeline |
-|-------|----------|--------|--------|----------|
-| Phase 1 | HIGH | High | Medium | Week 1-2 |
-| Phase 2 | HIGH | High | Medium-High | Week 2-3 |
-| Phase 3 | MEDIUM | Medium-High | Medium-High | Week 3-4 |
-| Phase 4 | MEDIUM | High | High | Week 4-5 |
-| Phase 5 | LOW | Medium | Medium | Week 5-6 |
-
-## Success Metrics
-
-**Code Quality:**
-- Lines of code in `app.py`: Target <2,500 (from 5,069)
-- Cyclomatic complexity: Reduce by 40%
-- Test coverage: Achieve 80%+ for service layer
-- All tests passing (currently 40% success rate)
-
-**Performance:**
-- SP500 analysis response time: <30 seconds (from current 60+ seconds)
-- Market movers response time: <2 seconds (from current 5+ seconds)
-- Dashboard load time: <3 seconds (from current 8+ seconds)
-- Overall API throughput: +35% minimum
-
-**Maintainability:**
-- Clear separation of concerns across all modules
-- Consistent error handling patterns
-- Standardized caching implementation
-- Comprehensive logging and monitoring
-- Fixed dependency issues (lxml, xml parser)
-
-## Current Test Status
-- **Comprehensive System Test**: ✅ PASSED - All core functionality working
-- **API Endpoint Tests**: ✅ PASSED - All major endpoints responding correctly
-- **Integration Tests**: ❌ FAILED - 12/16 tests failing due to missing dependencies
-- **Unit Tests**: ❌ FAILED - Dependency issues
-- **Web Page Data Test**: ❌ FAILED - File not found
-
-**Critical Issues to Address:**
-1. Install missing dependencies: `lxml` and `xml` parser
-2. Fix test file paths and missing test modules
-3. Resolve API response format inconsistencies
-4. Improve error handling in test suite
-
-## Current Implementation Progress (September 2025)
-
-### ✅ Completed Refactoring (40% of routes moved):
-- **Analysis Routes**: sp500_analysis, crypto_analysis, analyze_stock, enhanced_analysis, comprehensive_analysis
-- **Backtest Routes**: All backtesting functionality moved to dedicated blueprint
-- **System Routes**: system_status, logs, performance_status, news_services management
-- **Telegram Routes**: Complete telegram integration moved to blueprint
-- **Page Routes**: All HTML template rendering moved to blueprint
-- **Logging Routes**: Client-side logging endpoints moved to blueprint
-
-### 🔄 In Progress:
-- Route modularization: 54 routes still in main app.py
-- Service layer implementation: Framework exists but needs completion
-- Test suite fixes: Dependency issues causing failures
-
-### 📊 Current Metrics:
-- **Lines in app.py**: 5,069 (target: <2,500)
-- **Routes moved to blueprints**: ~40% (43 routes in blueprints, 54 still in app.py)
-- **Test success rate**: 40% (2/5 test suites passing)
-- **Core functionality**: ✅ Working (comprehensive system test passes)
-- **API endpoints**: ✅ Working (all major endpoints responding)
-
-### 🎯 Next Priority Actions:
-1. **Immediate**: Fix missing dependencies (`pip install lxml`)
-2. **Week 1**: Move remaining 54 routes to appropriate blueprints
-3. **Week 2**: Complete service layer implementation
-4. **Week 3**: Optimize database access and caching
-5. **Week 4**: Performance tuning and async improvements
+## 12. Success Metrics
+- Lines in `app.py` <2,500 and cyclomatic complexity ↓40%.
+- SP500 analysis response time <30 s; market_movers <2 s; dashboard load <3 s.
+- Test coverage ≥80% for service layer; all tests passing after split.
 


### PR DESCRIPTION
## Summary
- merge app.py refactor roadmap with new core-service/app-ui split strategy
- outline interface contract, auth basics, migration phases, and repo layouts for future separation

## Testing
- `pytest tests/unit -q` *(fails: ModuleNotFoundError: No module named 'core.config')*


------
https://chatgpt.com/codex/tasks/task_e_68c525e79dbc832abf8cf10514512e4b