### PR TITLE
Add scalping signals template and route

### DIFF
--- a/src/web/app.py
+++ b/src/web/app.py
@@ -6,7 +6,7 @@ import threading
 import logging
 import psutil
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, render_template
 from flask_cors import CORS
 from flask_socketio import SocketIO
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -37,7 +37,7 @@ def create_api_response(data=None, success=True, error=None, status_code=200):
         status_code,
     )
 
-app = Flask(__name__)
+app = Flask(__name__, template_folder="templates")
 CORS(
     app,
     origins="*",
@@ -303,6 +303,12 @@ def get_preloaded_data():
             error=str(e),
             success=False,
         )
+
+
+@app.route("/scalping_signals")
+def scalping_signals():
+    """Render the scalping signals page."""
+    return render_template("scalping_signals.html")
 
 
 def create_app(port: int = 5001):

--- a/src/web/templates/scalping_signals.html
+++ b/src/web/templates/scalping_signals.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Scalping Signals</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+    <div class="container mt-4">
+        <h1 class="mb-4">Scalping Signals</h1>
+        <div id="signals" class="table-responsive">
+            <!-- Scalping signals will be populated here -->
+            <p class="text-muted">No signals available.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add scalping_signals.html template for new scalping signals page
- Configure Flask app to use templates folder and serve scalping signals route
- Ensure no legacy scalping_signals files remain

## Testing
- `pytest -q`
- `python -m py_compile src/web/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6edc79b14832a8033f9fe48d3a14c