### PR TITLE
Streamline web app factory and centralize configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,11 @@ populate_market_movers.py.log
 node_modules/
 
 # Sensitive configuration files
-src/core/config.py
+config/secrets.yaml
+config/secrets.yml
+secrets.yaml
+secrets.yml
 
 # Test artifacts
 .pytest_cache/
-test-artifacts/src/core/config.py
+test-artifacts/

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ pip install -r requirements.txt
 ```
 
 ### 3. Configure API Keys
-**⚠️ IMPORTANT: Copy and configure the config file before starting:**
+**⚠️ IMPORTANT: Provide your API keys before starting:**
 
 ```bash
-# Copy the template configuration
-cp src/core/config.template.py src/core/config.py
+# Copy the secrets template
+cp config/secrets.example.yaml config/secrets.yaml
 
-# Edit the config file with your API keys
-nano src/core/config.py  # or use your preferred editor
+# Edit the secrets file with your API keys
+nano config/secrets.yaml  # or use your preferred editor
 ```
 
 **Required API Keys:**
@@ -84,7 +84,9 @@ nano src/core/config.py  # or use your preferred editor
 - **News API**: At [newsapi.org](https://newsapi.org) (optional)
 - **Telegram**: Create bot at [@BotFather](https://t.me/botfather) (optional)
 
-**Note:** The config file contains sensitive API keys and is excluded from the repository for security.
+**Note:** `config/secrets.yaml` is excluded from version control. You can also
+set environment variables (for example `ALPHA_VANTAGE_API_KEY`) to override the
+values stored in the secrets file.
 
 ### 4. Startup
 ```bash
@@ -624,28 +626,22 @@ Advanced trading platform with enhanced analysis capabilities.
 
 ### Required Setup Steps:
 
-1. **Copy the template configuration:**
+1. **Copy the secrets template:**
    ```bash
-   cp src/core/config.template.py src/core/config.py
+   cp config/secrets.example.yaml config/secrets.yaml
    ```
 
-2. **Update API keys in `src/core/config.py`:**
-   ```python
-   # Required API Keys
-   ALPHA_VANTAGE_API_KEY = "your_alpha_vantage_api_key_here"
-   FINNHUB_API_KEY = "your_finnhub_api_key_here"
-   NEWS_API_KEY = "your_news_api_key_here"
-   OPENAI_API_KEY = "your_openai_api_key_here"
-   
-   # Optional API Keys
-   CRYPTOPANIC_API_KEY = "your_cryptopanic_api_key_here"
-   TELEGRAM_API_KEY = "your_telegram_api_key_here"
-   REDDIT_CLIENT_ID = "your_reddit_client_id_here"
-   REDDIT_SECRET_KEY = "your_reddit_secret_key_here"
-   DEEPSEEK_API_KEY = "your_deepseek_api_key_here"
-   ```
+2. **Fill in your keys:**
+   Update `config/secrets.yaml` with the required API keys (or set the matching
+   environment variables). The configuration loader automatically picks up
+   values from either location.
 
-3. **Get your API keys:**
+3. **Override via environment (optional):**
+   Any configuration entry can be overridden with environment variables such as
+   `ALPHA_VANTAGE_API_KEY`, `TRADING_AI_ALPHA_VANTAGE_API_KEY`, or
+   `FLASK_SECRET_KEY`. These take precedence over `secrets.yaml`.
+
+4. **Get your API keys:**
    - **Finnhub**: Free at [finnhub.io](https://finnhub.io) (required)
    - **Alpha Vantage**: Free at [alphavantage.co](https://alphavantage.co) (optional)
    - **OpenAI**: At [platform.openai.com](https://platform.openai.com) (optional if using Ollama)
@@ -657,12 +653,14 @@ Advanced trading platform with enhanced analysis capabilities.
 
 The following files contain sensitive information and are excluded from the repository:
 
-- `src/core/config.py` - Contains API keys and configuration settings
 - `.env` - Environment variables (if used)
-- `docs/NOTES.txt` - Contains AWS credentials  
+- `docs/NOTES.txt` - Contains AWS credentials
 - `git_manager.py` - Contains GitHub token
 
-**Note:** The `src/core/config.template.py` file is included as a template for easy setup.
+**Note:** `src/core/config.py` is now committed and reads from environment
+variables or `config/secrets.yaml`. The original
+`src/core/config.template.py` remains as an extended reference of the available
+settings.
 
 **Security:** All sensitive files are properly excluded via `.gitignore` to prevent accidental commits of API keys and credentials.
 

--- a/config/secrets.example.yaml
+++ b/config/secrets.example.yaml
@@ -1,0 +1,21 @@
+# Example secrets configuration for the Trading AI platform.
+# Copy this file to `config/secrets.yaml` (or set the TRADING_AI_SECRETS_FILE
+# environment variable) and fill in your real keys. Any value can also be
+# supplied via environment variables with the same name.
+
+SECRET_KEY: "replace-me"
+ALPHA_VANTAGE_API_KEY: "your_alpha_vantage_api_key_here"
+FINNHUB_API_KEY: "your_finnhub_api_key_here"
+NEWS_API_KEY: "your_news_api_key_here"
+NEWSAPI_API_KEY: "your_newsapi_api_key_here"
+OPENAI_API_KEY: "your_openai_api_key_here"
+CRYPTOPANIC_API_KEY: "your_cryptopanic_api_key_here"
+REDDIT_CLIENT_ID: "your_reddit_client_id_here"
+REDDIT_SECRET_KEY: "your_reddit_secret_key_here"
+POLYGON_API_KEY: "your_polygon_api_key_here"
+MARKETAUX_API_KEY: "your_marketaux_api_key_here"
+DEEPSEEK_API_KEY: "your_deepseek_api_key_here"
+TELEGRAM_API_KEY: "your_telegram_api_key_here"
+TELEGRAM_CHAT_IDS:
+  - "primary_chat_id"
+  - "backup_chat_id"

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,0 +1,249 @@
+"""Runtime configuration management for the Trading AI platform."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from datetime import timedelta
+from pathlib import Path
+from typing import Any, Dict, Mapping
+
+try:  # Optional dependency used for secrets.yaml parsing
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency may be absent
+    yaml = None
+
+
+def _load_template_config() -> type:
+    """Load the template Config class shipped with the repository."""
+
+    template_path = Path(__file__).with_name("config.template.py")
+    spec = importlib.util.spec_from_file_location("config_template", template_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise ImportError(f"Unable to load configuration template from {template_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, "Config")
+
+
+_TEMPLATE_CONFIG = _load_template_config()
+
+
+def _flatten(mapping: Mapping[str, Any], prefix: str = "") -> Dict[str, Any]:
+    """Flatten nested mapping keys into an uppercase dictionary."""
+
+    flat: Dict[str, Any] = {}
+    for key, value in mapping.items():
+        if not isinstance(key, str):
+            continue
+        normalized = key.strip()
+        if not normalized:
+            continue
+        combined = f"{prefix}_{normalized}" if prefix else normalized
+        combined_key = combined.upper()
+        if isinstance(value, Mapping):
+            flat.update(_flatten(value, combined))
+        else:
+            flat[combined_key] = value
+            if prefix:
+                flat[normalized.upper()] = value
+    return flat
+
+
+def _read_yaml(path: Path) -> Dict[str, Any]:
+    """Read a YAML file if PyYAML is installed and the file exists."""
+
+    if yaml is None or not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if isinstance(data, Mapping):
+        return _flatten(data)
+    return {}
+
+
+def _load_secrets() -> Dict[str, Any]:
+    """Load secrets from the preferred locations."""
+
+    candidates = []
+    env_candidate = os.getenv("TRADING_AI_SECRETS_FILE")
+    if env_candidate:
+        candidates.append(Path(env_candidate))
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates.extend(
+        [
+            repo_root / "secrets.yaml",
+            repo_root / "secrets.yml",
+            repo_root / "config" / "secrets.yaml",
+            repo_root / "config" / "secrets.yml",
+        ]
+    )
+
+    for candidate in candidates:
+        if candidate and candidate.exists():
+            secrets = _read_yaml(candidate)
+            if secrets:
+                return secrets
+    return {}
+
+
+_SECRETS = _load_secrets()
+
+
+def _lookup_env(name: str) -> Any | None:
+    """Return the first matching environment variable for the configuration key."""
+
+    normalized = name.upper()
+    candidates = (
+        normalized,
+        name,
+        f"TRADING_AI_{normalized}",
+        f"TRADING_AI_{name}",
+    )
+    for key in candidates:
+        if key in os.environ:
+            return os.environ[key]
+
+    suffix = f"_{normalized}"
+    for key, value in os.environ.items():
+        if key.endswith(suffix):
+            return value
+    return None
+
+
+def _lookup_secret(name: str) -> Any | None:
+    """Return a secret override for the given configuration key."""
+
+    normalized = name.upper()
+    candidates = (
+        normalized,
+        f"TRADING_AI_{normalized}",
+    )
+    for key in candidates:
+        if key in _SECRETS:
+            return _SECRETS[key]
+
+    suffix = f"_{normalized}"
+    for key, value in _SECRETS.items():
+        if key.endswith(suffix):
+            return value
+    return None
+
+
+def _coerce_type(value: Any, default: Any) -> Any:
+    """Convert environment or secret values to match the default type."""
+
+    if value is None:
+        return default
+
+    if isinstance(default, bool):
+        if isinstance(value, bool):
+            return value
+        return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+    if isinstance(default, int) and not isinstance(value, bool):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+
+    if isinstance(default, float):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    if isinstance(default, (list, tuple, set, frozenset)):
+        if isinstance(value, str):
+            parts = [item.strip() for item in value.split(",") if item.strip()]
+        elif isinstance(value, (list, tuple, set, frozenset)):
+            parts = [str(item).strip() for item in value if str(item).strip()]
+        else:
+            parts = [str(value).strip()]
+        if isinstance(default, tuple):
+            return tuple(parts)
+        if isinstance(default, set):
+            return set(parts)
+        if isinstance(default, frozenset):
+            return frozenset(parts)
+        return parts
+
+    if isinstance(default, timedelta):
+        if isinstance(value, timedelta):
+            return value
+        try:
+            minutes = float(value)
+        except (TypeError, ValueError):
+            return default
+        return timedelta(minutes=minutes)
+
+    return value
+
+
+def _get_config_value(name: str, default: Any) -> Any:
+    """Resolve the effective configuration value for ``name``."""
+
+    env_value = _lookup_env(name)
+    if env_value not in (None, ""):
+        return _coerce_type(env_value, default)
+
+    secret_value = _lookup_secret(name)
+    if secret_value not in (None, ""):
+        return _coerce_type(secret_value, default)
+
+    return default
+
+
+class Config(_TEMPLATE_CONFIG):
+    """Configuration object that honours environment variables and secrets."""
+
+    # Additional defaults tailored to the Flask web layer
+    JSON_SORT_KEYS = False
+    JSONIFY_PRETTYPRINT_REGULAR = False
+    SESSION_DURATION_MINUTES = 10
+    SEND_FILE_MAX_AGE_DEFAULT = 31536000
+    SOCKETIO_CORS_ALLOWED_ORIGINS = "*"
+    SOCKETIO_PING_TIMEOUT = getattr(_TEMPLATE_CONFIG, "ENHANCED_ANALYSIS_TIMEOUT", 60)
+    SOCKETIO_PING_INTERVAL = 25
+    CORS_ORIGINS = "*"
+    CORS_METHODS = ("GET", "POST", "PUT", "DELETE", "OPTIONS")
+    CORS_ALLOW_HEADERS = ("Content-Type", "Authorization")
+    CORS_SUPPORTS_CREDENTIALS = False
+
+    # Optional API integrations that are referenced throughout the codebase
+    NEWSAPI_API_KEY = ""
+    MARKETAUX_API_KEY = ""
+    POLYGON_API_KEY = ""
+
+
+def _apply_overrides() -> None:
+    """Apply environment and secrets overrides to the Config class."""
+
+    for attr in dir(Config):
+        if not attr.isupper():
+            continue
+        default = getattr(Config, attr)
+        overridden = _get_config_value(attr, default)
+        setattr(Config, attr, overridden)
+
+    Config.DEBUG = bool(Config.DEBUG)
+    Config.DEBUG_MODE = bool(getattr(Config, "DEBUG_MODE", False) or Config.DEBUG)
+    Config.ENV = "development" if Config.DEBUG_MODE else "production"
+
+    Config.PORT = int(getattr(Config, "PORT", 5001))
+    Config.HOST = getattr(Config, "HOST", "0.0.0.0")
+    Config.WEB_PORT = int(getattr(Config, "WEB_PORT", Config.PORT))
+    Config.WEB_HOST = getattr(Config, "WEB_HOST", Config.HOST)
+
+    Config.SESSION_DURATION_MINUTES = int(getattr(Config, "SESSION_DURATION_MINUTES", 10))
+    Config.PERMANENT_SESSION_LIFETIME = timedelta(minutes=Config.SESSION_DURATION_MINUTES)
+
+    Config.SEND_FILE_MAX_AGE_DEFAULT = int(getattr(Config, "SEND_FILE_MAX_AGE_DEFAULT", 31536000))
+    Config.SOCKETIO_PING_TIMEOUT = int(getattr(Config, "SOCKETIO_PING_TIMEOUT", 60))
+    Config.SOCKETIO_PING_INTERVAL = int(getattr(Config, "SOCKETIO_PING_INTERVAL", 25))
+
+
+_apply_overrides()
+
+
+__all__ = ["Config"]

--- a/src/web/app.py
+++ b/src/web/app.py
@@ -1,59 +1,44 @@
 """Application factory and Socket.IO setup for Trading AI UI."""
-from datetime import timedelta
+from __future__ import annotations
 
 from flask import Flask
-from flask_cors import CORS
 
-from .extensions import socketio
-from .routes import register_routes
-from .utils.page_logger import page_logger
 from src.core.config import Config
 
-
-log_info = page_logger.info
-log_error = page_logger.error
-log_exception = page_logger.exception
-trading_logger = page_logger.logger
+from .extensions import init_extensions, socketio
+from .routes import register_routes
+from .utils.page_logger import page_logger
 
 
-def create_flask_app() -> Flask:
+def create_flask_app(config_object: type[Config] = Config) -> Flask:
     """Create and configure the Flask application instance."""
+
     app = Flask(__name__)
+    app.config.from_object(config_object)
     register_routes(app)
-
-    CORS(
-        app,
-        origins="*",
-        allow_headers=["Content-Type", "Authorization"],
-        methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-    )
-
-    app.debug = True
-    app.config.update(
-        DEBUG=True,
-        ENV="development",
-        SECRET_KEY="trading_ai_secret_key_change_in_production",
-        SEND_FILE_MAX_AGE_DEFAULT=31536000,
-        PERMANENT_SESSION_LIFETIME=timedelta(minutes=10),
-    )
-
-    socketio.init_app(
-        app,
-        cors_allowed_origins="*",
-        ping_timeout=getattr(Config, "ENHANCED_ANALYSIS_TIMEOUT", 60),
-        ping_interval=25,
-    )
-
+    init_extensions(app)
     return app
 
 
 app = create_flask_app()
 
 
-def create_app(host: str = "0.0.0.0", port: int = 5001) -> Flask:
+def create_app(host: str | None = None, port: int | None = None) -> Flask:
     """Entry point used by start_app.py to launch the server."""
-    log_info(f"Starting Trading AI UI on {host}:{port}", "system")
-    socketio.run(app, host=host, port=port, debug=False, allow_unsafe_werkzeug=True)
+
+    host = host or app.config.get("HOST", "0.0.0.0")
+    port = port or app.config.get("PORT", 5001)
+    page_logger.info(
+        f"Starting Trading AI UI on {host}:{port} (debug={app.debug})",
+        "system",
+    )
+    socketio.run(
+        app,
+        host=host,
+        port=port,
+        debug=app.debug,
+        allow_unsafe_werkzeug=True,
+    )
     return app
 
 

--- a/src/web/extensions.py
+++ b/src/web/extensions.py
@@ -1,7 +1,68 @@
 """Application extensions for the Trading AI web app."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence
+
+from flask import Flask
+from flask_cors import CORS
 from flask_socketio import SocketIO
 
-# Socket.IO instance shared across blueprints
-socketio = SocketIO(cors_allowed_origins="*")
+# Shared extension instances
+socketio = SocketIO()
+cors = CORS()
 
-__all__ = ["socketio"]
+
+def _as_sequence(value: Any) -> Sequence[str]:
+    """Normalize configuration values that can be expressed as CSV strings."""
+
+    if isinstance(value, str):
+        return tuple(part.strip() for part in value.split(",") if part.strip())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    if value is None:
+        return tuple()
+    return (str(value).strip(),)
+
+
+def _build_cors_resources(app: Flask) -> Dict[str, Dict[str, Any]]:
+    """Create the CORS resources map using the application configuration."""
+
+    resources = app.config.get("CORS_RESOURCES")
+    origins = app.config.get("CORS_ORIGINS", "*")
+    if resources:
+        return resources
+    return {r"/*": {"origins": origins}}
+
+
+def init_extensions(app: Flask) -> None:
+    """Initialize Flask extensions bound to the application instance."""
+
+    origins = app.config.get("CORS_ORIGINS", "*")
+    methods = _as_sequence(
+        app.config.get("CORS_METHODS", ("GET", "POST", "PUT", "DELETE", "OPTIONS"))
+    ) or ("GET", "POST", "PUT", "DELETE", "OPTIONS")
+    allow_headers = _as_sequence(
+        app.config.get("CORS_ALLOW_HEADERS", ("Content-Type", "Authorization"))
+    ) or ("Content-Type", "Authorization")
+
+    cors.init_app(
+        app,
+        resources=_build_cors_resources(app),
+        origins=origins,
+        methods=methods,
+        allow_headers=allow_headers,
+        supports_credentials=app.config.get("CORS_SUPPORTS_CREDENTIALS", False),
+    )
+
+    socketio.init_app(
+        app,
+        cors_allowed_origins=app.config.get(
+            "SOCKETIO_CORS_ALLOWED_ORIGINS", origins
+        ),
+        ping_timeout=app.config.get("SOCKETIO_PING_TIMEOUT", 60),
+        ping_interval=app.config.get("SOCKETIO_PING_INTERVAL", 25),
+    )
+
+
+__all__ = ["socketio", "cors", "init_extensions"]


### PR DESCRIPTION
## Summary
- slim down `src/web/app.py` by delegating CORS and Socket.IO wiring to the extensions module while reusing the shared config
- add a committed `src/core/config.py` that loads defaults, secrets, and environment overrides plus an example `config/secrets.yaml`
- document the new secrets workflow, ignore local secrets files, and keep Flask JSON/performance toggles in configuration for leaner responses

## Testing
- pytest *(fails: optional Playwright dependency is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9895eb09c832ab6d600e4327bc952