### PR TITLE
Enforce dark theme and apply green market styling

### DIFF
--- a/src/web/static/css/styles.css
+++ b/src/web/static/css/styles.css
@@ -1,36 +1,40 @@
 /* Trading AI Dashboard - Main Styles */
 
 :root {
-    --primary-color: #007bff;
+    --primary-color: #00c853;
     --secondary-color: #6c757d;
-    --success-color: #28a745;
-    --danger-color: #dc3545;
-    --warning-color: #ffc107;
-    --info-color: #17a2b8;
-    --light-color: #f8f9fa;
-    --dark-color: #343a40;
-}
-
-[data-theme="dark"] {
-    --bs-body-bg: #121212;
-    --bs-body-color: #ffffff;
-    --bs-card-bg: #1e1e1e;
-    --bs-border-color: #333333;
-    --results-bg: #252525;
-}
-
-[data-theme="light"] {
-    --bs-body-bg: #ffffff;
-    --bs-body-color: #000000;
-    --bs-card-bg: #ffffff;
-    --bs-border-color: #dee2e6;
-    --results-bg: #f8f9fa;
+    --success-color: #00e676;
+    --danger-color: #ff3d00;
+    --warning-color: #ffd54f;
+    --info-color: #26c6da;
+    --light-color: #1b1f23;
+    --dark-color: #0a0f0d;
+    --bs-body-bg: #080b0a;
+    --bs-body-color: #e0f2f1;
+    --bs-card-bg: #101614;
+    --bs-border-color: #1d2a24;
+    --results-bg: #0f1a17;
+    --table-header-bg: #122820;
+    --table-row-bg: rgba(9, 28, 20, 0.7);
+    --table-row-hover-bg: rgba(12, 36, 25, 0.85);
+    --table-text-strong: #76ffb2;
+    --muted-green: #4caf50;
 }
 
 body {
     background-color: var(--bs-body-bg);
     color: var(--bs-body-color);
     transition: all 0.3s ease;
+}
+
+a,
+.nav-link {
+    color: var(--table-text-strong);
+}
+
+a:hover,
+.nav-link:hover {
+    color: var(--success-color);
 }
 
 .card {
@@ -80,15 +84,6 @@ body {
 .status-working { background-color: #007bff; animation: pulse 1s infinite; }
 .status-success { background-color: #28a745; }
 .status-error { background-color: #dc3545; }
-
-.theme-toggle {
-    cursor: pointer;
-    transition: transform 0.3s ease;
-}
-
-.theme-toggle:hover {
-    transform: scale(1.1);
-}
 
 .navbar-brand {
     font-weight: bold;
@@ -153,6 +148,61 @@ body {
     background-color: var(--bs-card-bg);
     border-top: 1px solid var(--bs-border-color);
     margin-top: 3rem;
+}
+
+table {
+    color: var(--table-text-strong);
+}
+
+.table thead th {
+    background-color: var(--table-header-bg);
+    color: var(--success-color);
+    border-bottom: 2px solid var(--bs-border-color);
+}
+
+.table tbody tr {
+    background-color: var(--table-row-bg);
+    border-color: var(--bs-border-color);
+}
+
+.table tbody tr:hover {
+    background-color: var(--table-row-hover-bg);
+}
+
+.table tbody td,
+.table tbody th {
+    color: var(--table-text-strong);
+}
+
+.text-success,
+.badge.bg-success {
+    color: var(--success-color) !important;
+}
+
+.badge.bg-success {
+    background-color: rgba(0, 230, 118, 0.15) !important;
+    border: 1px solid var(--success-color);
+}
+
+.progress-bar,
+.btn-primary,
+.bg-success {
+    background-color: var(--primary-color) !important;
+    border-color: var(--primary-color) !important;
+}
+
+.btn-outline-info {
+    color: var(--table-text-strong);
+    border-color: var(--table-text-strong);
+}
+
+.btn-outline-info:hover {
+    background-color: var(--table-text-strong);
+    color: #0a0f0d;
+}
+
+.text-muted {
+    color: #8aa899 !important;
 }
 
 /* Additional utility styles for common UI elements */

--- a/src/web/static/js/base.js
+++ b/src/web/static/js/base.js
@@ -1,47 +1,15 @@
 /* Trading AI Dashboard - Base JavaScript */
 
-// Theme management
-function toggleTheme() {
-    try {
-        if (window.frontendLogger && typeof window.frontendLogger.logUserAction === 'function') {
-            window.frontendLogger.logUserAction('Theme Toggle Clicked');
-        }
-        
-        const html = document.documentElement;
-        const currentTheme = html.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        
-        html.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
-        
-        const icon = document.getElementById('themeIcon');
-        if (icon) {
-            if (newTheme === 'dark') {
-                icon.className = 'fas fa-moon';
-            } else {
-                icon.className = 'fas fa-sun';
-            }
-        }
-        
-        if (window.frontendLogger && typeof window.frontendLogger.logUserAction === 'function') {
-            window.frontendLogger.logUserAction('Theme Changed', null, { from: currentTheme, to: newTheme });
-        }
-    } catch (e) {
-        console.error('Error in toggleTheme:', e);
-    }
-}
-
-// Initialize theme from localStorage
-function initializeTheme() {
-    const savedTheme = localStorage.getItem('theme') || 'dark';
+// Enforce dark theme
+function enforceDarkTheme() {
     const html = document.documentElement;
-    html.setAttribute('data-theme', savedTheme);
-    
-    const icon = document.getElementById('themeIcon');
-    if (savedTheme === 'dark') {
-        icon.className = 'fas fa-moon';
-    } else {
-        icon.className = 'fas fa-sun';
+    if (html.getAttribute('data-theme') !== 'dark') {
+        html.setAttribute('data-theme', 'dark');
+    }
+    try {
+        localStorage.setItem('theme', 'dark');
+    } catch (error) {
+        console.warn('Unable to persist dark theme preference:', error);
     }
 }
 
@@ -159,7 +127,7 @@ function debugLog(message, data = null) {
 // Initialize theme on page load
 document.addEventListener('DOMContentLoaded', function() {
     try {
-        initializeTheme();
+        enforceDarkTheme();
         if (window.frontendLogger && typeof window.frontendLogger.info === 'function') {
             window.frontendLogger.info('Page Loaded: ' + window.location.href, 'navigation');
         } else {

--- a/src/web/templates/navbar.html
+++ b/src/web/templates/navbar.html
@@ -102,13 +102,6 @@
                 </li>
             </ul>
             
-            <ul class="navbar-nav">
-                <li class="nav-item">
-                    <span class="nav-link theme-toggle" onclick="toggleTheme()">
-                        <i class="fas fa-moon" id="themeIcon"></i>
-                    </span>
-                </li>
-            </ul>
         </div>
     </div>
-</nav> 
+</nav>


### PR DESCRIPTION
## Summary
- remove the navbar theme toggle and lock the UI into the dark palette
- enforce the dark theme in the base JavaScript and simplify the theme logic
- refresh the global styles with green-accented tables and components to match the trading focus

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_68cadb06ab40832a8c1caba1965c3f22