### PR TITLE
Limit weekly plan to single-week window

### DIFF
--- a/src/web/routes/market_routes.py
+++ b/src/web/routes/market_routes.py
@@ -1,5 +1,6 @@
 """Routes for market overviews, calendars, and weekly plans."""
 from datetime import datetime, timedelta
+from typing import Optional
 
 from flask import Blueprint, jsonify, request
 
@@ -13,6 +14,34 @@ market_bp = Blueprint("market", __name__)
 
 trading_logger = page_logger.logger
 log_exception = page_logger.exception
+
+
+EVENT_TYPE_TO_GROUP = {
+    "earnings": "earnings",
+    "federal_reserve": "federal_reserve",
+    "economic": "economic",
+    "economic_data": "economic",
+    "economic_event": "economic",
+    "economic_events": "economic",
+    "options_expiration": "options_expiration",
+    "market_holiday": "market_holidays",
+    "market_holidays": "market_holidays",
+}
+
+
+def _safe_int(value: Optional[str], default: int, *, param_name: str) -> int:
+    """Parse integers from query params without surfacing ValueError."""
+
+    if value is None:
+        return default
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        trading_logger.error_logger.warning(
+            "[WARN] Invalid integer for %s in weekly_events API: %s", param_name, value
+        )
+        return default
 
 
 @market_bp.route("/api/foreign_markets/overview")
@@ -36,10 +65,43 @@ def weekly_events_api():
     """Return weekly market events grouped by type."""
     try:
         trading_logger.api_logger.info("[DEBUG] Entered weekly_events API endpoint")
-        weeks_back = int(request.args.get("weeks_back", 1))
-        weeks_ahead = int(request.args.get("weeks_ahead", 1))
-        start_date = datetime.now().date() - timedelta(weeks=weeks_back)
-        end_date = datetime.now().date() + timedelta(weeks=weeks_ahead)
+
+        # Determine the reference date for the query window. If the UI supplies
+        # a specific start date we use that week as our anchor, otherwise we
+        # default to "today" so the page shows recent data when first loaded.
+        start_date_param = request.args.get("start_date")
+        if start_date_param:
+            try:
+                reference_date = datetime.strptime(start_date_param, "%Y-%m-%d").date()
+            except ValueError:
+                trading_logger.error_logger.warning(
+                    "[WARN] Invalid start_date supplied to weekly_events API: %s",
+                    start_date_param,
+                )
+                reference_date = datetime.now().date()
+        else:
+            reference_date = datetime.now().date()
+
+        # Allow callers to customise the lookback/lookahead window while
+        # defaulting to a full month in each direction as requested.
+        days_back = request.args.get("days_back")
+        days_ahead = request.args.get("days_ahead")
+        weeks_back = request.args.get("weeks_back")
+        weeks_ahead = request.args.get("weeks_ahead")
+
+        if weeks_back is not None or weeks_ahead is not None:
+            # Preserve backwards compatibility if any callers still rely on the
+            # old weeks-based parameters.  Fall back to four weeks (~one month)
+            # when one of the values is missing or invalid.
+            weeks_back_value = _safe_int(weeks_back, 4, param_name="weeks_back")
+            weeks_ahead_value = _safe_int(weeks_ahead, 4, param_name="weeks_ahead")
+            start_date = reference_date - timedelta(weeks=weeks_back_value)
+            end_date = reference_date + timedelta(weeks=weeks_ahead_value)
+        else:
+            days_back_value = _safe_int(days_back, 30, param_name="days_back")
+            days_ahead_value = _safe_int(days_ahead, 30, param_name="days_ahead")
+            start_date = reference_date - timedelta(days=days_back_value)
+            end_date = reference_date + timedelta(days=days_ahead_value)
 
         grouped_events = {
             "earnings": [],
@@ -71,9 +133,13 @@ def weekly_events_api():
                             "symbol": event["symbol"],
                             "timing": event["timing"] or "all_day",
                         }
-                        key = event["event_type"]
-                        if key in grouped_events:
-                            grouped_events[key].append(event_data)
+                        event_type = event["event_type"]
+                        group_key = EVENT_TYPE_TO_GROUP.get(event_type, event_type)
+
+                        if group_key not in grouped_events:
+                            grouped_events[group_key] = []
+
+                        grouped_events[group_key].append(event_data)
         except Exception as db_error:
             trading_logger.error_logger.error(
                 f"[ERROR] Database query failed: {str(db_error)}"

--- a/src/web/templates/weekly_plan.html
+++ b/src/web/templates/weekly_plan.html
@@ -199,6 +199,23 @@ function formatDate(date) {
     return tzAdjusted.toISOString().split('T')[0];
 }
 
+function getCurrentWeekBounds() {
+    const start = new Date(currentWeekStart);
+    const end = new Date(currentWeekStart);
+    end.setDate(end.getDate() + 6);
+    return { start, end };
+}
+
+function parseDateString(dateStr) {
+    const [year, month, day] = dateStr.split('-').map(Number);
+    return new Date(year, month - 1, day);
+}
+
+function isDateWithinRange(dateStr, startDate, endDate) {
+    const date = parseDateString(dateStr);
+    return date >= startDate && date <= endDate;
+}
+
 function changeWeek(direction) {
     const newDate = new Date(currentWeekStart);
     newDate.setDate(newDate.getDate() + (direction * 7));
@@ -225,7 +242,10 @@ function loadWeeklyEvents() {
     
     const weekStart = formatDate(currentWeekStart);
     
-    fetch(`/api/weekly_events?start_date=${weekStart}`)
+    const daysBack = 0;
+    const daysAhead = 6;
+
+    fetch(`/api/weekly_events?start_date=${weekStart}&days_back=${daysBack}&days_ahead=${daysAhead}`)
         .then(response => response.json())
         .then(response => {
             console.log('API Response:', response); // Debug log
@@ -349,12 +369,22 @@ function updateSummary() {
         economic: 0,
         options: 0
     };
-    
-    if (allEvents.earnings) counts.earnings = allEvents.earnings.length;
-    if (allEvents.federal_reserve) counts.fed = allEvents.federal_reserve.length;
-    if (allEvents.economic) counts.economic = allEvents.economic.length;
-    if (allEvents.options_expiration) counts.options = allEvents.options_expiration.length;
-    
+
+    const { start, end } = getCurrentWeekBounds();
+
+    if (allEvents.earnings) {
+        counts.earnings = allEvents.earnings.filter(event => isDateWithinRange(event.date, start, end)).length;
+    }
+    if (allEvents.federal_reserve) {
+        counts.fed = allEvents.federal_reserve.filter(event => isDateWithinRange(event.date, start, end)).length;
+    }
+    if (allEvents.economic) {
+        counts.economic = allEvents.economic.filter(event => isDateWithinRange(event.date, start, end)).length;
+    }
+    if (allEvents.options_expiration) {
+        counts.options = allEvents.options_expiration.filter(event => isDateWithinRange(event.date, start, end)).length;
+    }
+
     document.getElementById('earningsCount').textContent = counts.earnings;
     document.getElementById('fedCount').textContent = counts.fed;
     document.getElementById('economicCount').textContent = counts.economic;
@@ -373,18 +403,20 @@ function renderEventsTable() {
             });
         }
     });
-    
+
+    const { start, end } = getCurrentWeekBounds();
+    const weeklyEvents = allEventsList.filter(event => isDateWithinRange(event.date, start, end));
+
     // Sort by date
-    allEventsList.sort((a, b) => new Date(a.date) - new Date(b.date));
-    
+    weeklyEvents.sort((a, b) => parseDateString(a.date) - parseDateString(b.date));
+
     let html = '';
-    allEventsList.forEach(event => {
+    weeklyEvents.forEach(event => {
         // Parse date as local time to avoid timezone offset issues
-        const [year, month, day] = event.date.split('-').map(Number);
-        const date = new Date(year, month - 1, day); // month is 0-indexed
+        const date = parseDateString(event.date);
         const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
         const formattedDate = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-        
+
         html += `
             <tr class="event-row" data-type="${event.event_type}" data-impact="${event.impact}">
                 <td>${formattedDate}</td>


### PR DESCRIPTION
## Summary
- adjust the weekly plan view to request only the selected week's events from the API
- filter weekly summary cards and detailed table rows so they only reflect the current week's window

## Testing
- pytest --maxfail=1 *(fails: ModuleNotFoundError: No module named 'playwright')*


------
https://chatgpt.com/codex/tasks/task_e_68d45c7459a4832a96cacc63aa20ac4c