### PR TITLE
Revamp weekly plan layout

### DIFF
--- a/src/web/static/css/weekly_plan.css
+++ b/src/web/static/css/weekly_plan.css
@@ -1,0 +1,661 @@
+:root {
+    --weekly-hero-gradient: linear-gradient(135deg, rgba(0, 255, 136, 0.15) 0%, rgba(56, 198, 217, 0.08) 40%, rgba(0, 0, 0, 0.45) 100%);
+    --weekly-card-gradient: linear-gradient(135deg, rgba(34, 34, 34, 0.85) 0%, rgba(12, 12, 12, 0.92) 100%);
+    --weekly-card-border: rgba(0, 255, 136, 0.16);
+    --weekly-card-shadow: 0 18px 45px rgba(0, 255, 136, 0.08);
+    --weekly-today-border: rgba(0, 255, 136, 0.6);
+    --weekly-muted-text: rgba(255, 255, 255, 0.6);
+    --weekly-divider: rgba(255, 255, 255, 0.08);
+    --weekly-chip-bg: rgba(255, 255, 255, 0.06);
+    --weekly-chip-active: rgba(0, 255, 136, 0.18);
+    --weekly-chip-border: rgba(0, 255, 136, 0.35);
+    --weekly-badge-earnings: linear-gradient(135deg, rgba(0, 136, 255, 0.8), rgba(0, 68, 255, 0.6));
+    --weekly-badge-fed: linear-gradient(135deg, rgba(255, 68, 68, 0.9), rgba(150, 25, 25, 0.75));
+    --weekly-badge-economic: linear-gradient(135deg, rgba(0, 200, 120, 0.9), rgba(0, 122, 85, 0.75));
+    --weekly-badge-options: linear-gradient(135deg, rgba(255, 184, 51, 0.95), rgba(200, 120, 0, 0.75));
+    --weekly-badge-holiday: linear-gradient(135deg, rgba(142, 142, 164, 0.9), rgba(96, 96, 112, 0.7));
+}
+
+.weekly-plan-wrapper {
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.weekly-plan-hero {
+    background: var(--weekly-hero-gradient);
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    border-radius: 1.75rem;
+    padding: 2.5rem 3rem;
+    box-shadow: 0 35px 60px rgba(0, 255, 136, 0.08);
+    position: relative;
+    overflow: hidden;
+}
+
+.weekly-plan-hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 20% 20%, rgba(0, 255, 136, 0.25), transparent 60%),
+                radial-gradient(circle at 80% 30%, rgba(56, 198, 217, 0.15), transparent 55%),
+                radial-gradient(circle at 40% 80%, rgba(0, 255, 136, 0.12), transparent 65%);
+    opacity: 0.75;
+    pointer-events: none;
+}
+
+.weekly-plan-hero .hero-content {
+    position: relative;
+    z-index: 2;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.weekly-plan-hero h1 {
+    font-size: 2.5rem;
+    letter-spacing: 0.03em;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.weekly-plan-hero h1 i {
+    font-size: 2.75rem;
+    color: var(--primary-color);
+    filter: drop-shadow(0 0 12px rgba(0, 255, 136, 0.35));
+}
+
+.weekly-plan-hero .hero-subtitle {
+    font-size: 1.1rem;
+    max-width: 650px;
+    color: var(--weekly-muted-text);
+}
+
+.hero-meta {
+    display: flex;
+    align-items: center;
+    gap: 1.75rem;
+    flex-wrap: wrap;
+}
+
+.hero-meta .meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(0, 255, 136, 0.18);
+    border-radius: 999px;
+    padding: 0.55rem 1.25rem;
+    font-size: 0.95rem;
+    color: var(--text-primary);
+}
+
+.hero-meta .meta-item i {
+    color: var(--primary-color);
+}
+
+.weekly-controls {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.75rem;
+}
+
+.weekly-card {
+    background: var(--weekly-card-gradient);
+    border-radius: 1.5rem;
+    padding: 1.75rem;
+    border: 1px solid var(--weekly-card-border);
+    box-shadow: var(--weekly-card-shadow);
+    position: relative;
+    overflow: hidden;
+}
+
+.weekly-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(0, 255, 136, 0.12), transparent 55%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.weekly-card:hover::before {
+    opacity: 1;
+}
+
+.weekly-card h5 {
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    margin-bottom: 1.25rem;
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+}
+
+.week-selector {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.week-selector .selector-display {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.week-selector .selector-display .label {
+    color: var(--weekly-muted-text);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.week-selector .selector-display .value {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.selector-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.selector-controls button {
+    padding: 0.65rem 1.5rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+    font-weight: 600;
+    transition: all 0.25s ease;
+}
+
+.selector-controls button:hover {
+    background: rgba(0, 255, 136, 0.15);
+    border-color: var(--border-hover);
+    color: var(--primary-color);
+}
+
+.selector-controls input[type="date"] {
+    appearance: none;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    color: var(--text-primary);
+    padding: 0.65rem 1rem;
+    border-radius: 0.85rem;
+    font-weight: 600;
+}
+
+.selector-controls input[type="date"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+}
+
+.filter-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.85rem;
+}
+
+.filter-chip {
+    position: relative;
+}
+
+.filter-chip input {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.filter-chip label {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
+    background: var(--weekly-chip-bg);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 0.6rem 1.15rem;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    color: var(--weekly-muted-text);
+    transition: all 0.25s ease;
+}
+
+.filter-chip label i {
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.6);
+}
+
+.filter-chip input:checked + label {
+    color: var(--text-primary);
+    border-color: var(--weekly-chip-border);
+    background: var(--weekly-chip-active);
+    box-shadow: 0 8px 22px rgba(0, 255, 136, 0.08);
+}
+
+.weekly-calendar-section {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.weekly-calendar-section h4 {
+    font-weight: 600;
+    letter-spacing: 0.04em;
+}
+
+.weekly-calendar-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.week-module {
+    background: var(--weekly-card-gradient);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 1.75rem;
+    box-shadow: var(--weekly-card-shadow);
+}
+
+.week-module-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1.25rem;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.week-label {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.week-label .title {
+    font-size: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--weekly-muted-text);
+}
+
+.week-label .range {
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.week-total {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: rgba(0, 255, 136, 0.08);
+    border: 1px solid rgba(0, 255, 136, 0.35);
+    border-radius: 1.2rem;
+    padding: 0.75rem 1.4rem;
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.week-total span {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--weekly-muted-text);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.weekly-metrics {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.85rem;
+}
+
+.week-metric {
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 1rem;
+    padding: 0.9rem 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+    min-height: 110px;
+}
+
+.week-metric .metric-label {
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--weekly-muted-text);
+}
+
+.week-metric .metric-value {
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.week-metric .metric-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 38px;
+    height: 38px;
+    border-radius: 50%;
+    background: rgba(0, 255, 136, 0.1);
+    border: 1px solid rgba(0, 255, 136, 0.25);
+    color: var(--primary-color);
+}
+
+.week-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 1.1rem;
+    margin-top: 1.5rem;
+}
+
+.day-card {
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    min-height: 180px;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.3s ease;
+}
+
+.day-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(135deg, rgba(0, 255, 136, 0.1), transparent 60%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.day-card:hover::before {
+    opacity: 1;
+}
+
+.day-card.is-today {
+    border-color: var(--weekly-today-border);
+    box-shadow: 0 12px 28px rgba(0, 255, 136, 0.18);
+}
+
+.day-card.has-events {
+    border-color: rgba(0, 255, 136, 0.12);
+}
+
+.day-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    z-index: 2;
+}
+
+.day-header .day-name {
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+.day-header .day-date {
+    font-size: 0.85rem;
+    color: var(--weekly-muted-text);
+}
+
+.day-events {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 2;
+}
+
+.event-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 0.75rem;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    color: #fff;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    white-space: nowrap;
+    max-width: 100%;
+}
+
+.event-pill i {
+    font-size: 0.8rem;
+    opacity: 0.85;
+}
+
+.event-pill.earnings {
+    background: var(--weekly-badge-earnings);
+}
+
+.event-pill.fed {
+    background: var(--weekly-badge-fed);
+}
+
+.event-pill.economic {
+    background: var(--weekly-badge-economic);
+}
+
+.event-pill.options {
+    background: var(--weekly-badge-options);
+    color: #000;
+}
+
+.event-pill.holiday {
+    background: var(--weekly-badge-holiday);
+}
+
+.no-events {
+    font-size: 0.85rem;
+    color: var(--weekly-muted-text);
+}
+
+.summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1.5rem;
+}
+
+.summary-card {
+    background: var(--weekly-card-gradient);
+    border-radius: 1.4rem;
+    padding: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 22px 45px rgba(0, 255, 136, 0.08);
+    position: relative;
+    overflow: hidden;
+}
+
+.summary-card::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(0, 255, 136, 0.28), transparent 55%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.summary-card .summary-icon {
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 1rem;
+    background: rgba(0, 255, 136, 0.12);
+    border: 1px solid rgba(0, 255, 136, 0.3);
+    color: var(--primary-color);
+    font-size: 1.4rem;
+}
+
+.summary-card h3 {
+    font-size: 2.25rem;
+    font-weight: 700;
+}
+
+.summary-card p {
+    color: var(--weekly-muted-text);
+    margin: 0;
+}
+
+.detailed-events-card {
+    background: var(--weekly-card-gradient);
+    border-radius: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: var(--weekly-card-shadow);
+    padding: 1.5rem;
+}
+
+.detailed-events-card h5 {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+}
+
+.detailed-events-card h5 i {
+    color: var(--primary-color);
+}
+
+.table.unified-table {
+    color: var(--text-primary);
+    margin-bottom: 0;
+}
+
+.table.unified-table thead {
+    background: rgba(0, 255, 136, 0.05);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.table.unified-table thead th {
+    border: none;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.75rem;
+    color: var(--weekly-muted-text);
+}
+
+.table.unified-table tbody tr {
+    border-color: rgba(255, 255, 255, 0.05);
+    transition: background 0.25s ease;
+}
+
+.table.unified-table tbody tr:hover {
+    background: rgba(0, 255, 136, 0.05);
+}
+
+.type-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border-radius: 999px;
+    padding: 0.3rem 0.85rem;
+    font-size: 0.78rem;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.type-pill.earnings { background: var(--weekly-badge-earnings); }
+.type-pill.fed { background: var(--weekly-badge-fed); }
+.type-pill.economic { background: var(--weekly-badge-economic); }
+.type-pill.options { background: var(--weekly-badge-options); color: #000; }
+.type-pill.holiday { background: var(--weekly-badge-holiday); }
+
+.impact-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.3rem 0.85rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.impact-pill.high {
+    background: rgba(255, 82, 82, 0.18);
+    color: #ffb3b3;
+    border: 1px solid rgba(255, 82, 82, 0.35);
+}
+
+.impact-pill.medium {
+    background: rgba(255, 184, 51, 0.18);
+    color: #ffd699;
+    border: 1px solid rgba(255, 184, 51, 0.35);
+}
+
+.impact-pill.low {
+    background: rgba(56, 198, 217, 0.15);
+    color: #a8e9f0;
+    border: 1px solid rgba(56, 198, 217, 0.4);
+}
+
+#loadingIndicator {
+    background: rgba(0, 0, 0, 0.35);
+    border-radius: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+#loadingIndicator p {
+    color: var(--weekly-muted-text);
+}
+
+@media (max-width: 1199px) {
+    .weekly-controls {
+        grid-template-columns: 1fr;
+    }
+
+    .summary-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .weekly-metrics {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 991px) {
+    .week-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 767px) {
+    .weekly-plan-hero {
+        padding: 2rem;
+    }
+
+    .week-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .summary-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .weekly-metrics {
+        grid-template-columns: 1fr;
+    }
+
+    .selector-controls {
+        flex-wrap: wrap;
+        justify-content: flex-start;
+    }
+}

--- a/src/web/templates/weekly_plan.html
+++ b/src/web/templates/weekly_plan.html
@@ -2,181 +2,135 @@
 
 {% block title %}Weekly Market Plan - Trading AI{% endblock %}
 
+{% block extra_head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/weekly_plan.css') }}">
+{% endblock %}
+
 {% block content %}
-<div class="container-fluid">
-    <div class="row mb-4">
-        <div class="col-12">
-            <h1><i class="fas fa-calendar-week text-primary"></i> Weekly Market Plan</h1>
-            <p class="lead text-muted">Plan your trading week with key market events and announcements</p>
+<div class="weekly-plan-wrapper">
+    <section class="weekly-plan-hero">
+        <div class="hero-content">
+            <h1><i class="fas fa-calendar-week"></i> Weekly Market Plan</h1>
+            <p class="hero-subtitle">Plan your trading week with precision. Track the events that move the markets, prioritize the catalysts that matter, and stay ahead of macro and micro narratives.</p>
+            <div class="hero-meta">
+                <div class="meta-item"><i class="fas fa-globe"></i> Global Macro Coverage</div>
+                <div class="meta-item"><i class="fas fa-bolt"></i> Auto-ranked Catalysts</div>
+                <div class="meta-item"><i class="fas fa-shield-check"></i> Risk-aware Filtering</div>
+            </div>
         </div>
+    </section>
+
+    <section class="weekly-controls">
+        <div class="weekly-card">
+            <h5><i class="fas fa-calendar"></i> Week Selection</h5>
+            <div class="week-selector">
+                <div class="selector-display">
+                    <span class="label">Current Focus</span>
+                    <span class="value" id="selectedWeekLabel">Loading…</span>
+                </div>
+                <div class="selector-controls">
+                    <button type="button" onclick="changeWeek(-1)"><i class="fas fa-chevron-left"></i> Prev</button>
+                    <input type="date" id="weekSelector" onchange="selectWeek()">
+                    <button type="button" onclick="changeWeek(1)">Next <i class="fas fa-chevron-right"></i></button>
+                </div>
+            </div>
+        </div>
+        <div class="weekly-card">
+            <h5><i class="fas fa-filter"></i> Event Filters</h5>
+            <div class="filter-chips">
+                <div class="filter-chip">
+                    <input type="checkbox" id="filterEarnings" checked onchange="filterEvents()">
+                    <label for="filterEarnings"><i class="fas fa-chart-line"></i> Earnings</label>
+                </div>
+                <div class="filter-chip">
+                    <input type="checkbox" id="filterFed" checked onchange="filterEvents()">
+                    <label for="filterFed"><i class="fas fa-university"></i> Fed Events</label>
+                </div>
+                <div class="filter-chip">
+                    <input type="checkbox" id="filterEconomic" checked onchange="filterEvents()">
+                    <label for="filterEconomic"><i class="fas fa-chart-bar"></i> Economic Data</label>
+                </div>
+                <div class="filter-chip">
+                    <input type="checkbox" id="filterOptions" checked onchange="filterEvents()">
+                    <label for="filterOptions"><i class="fas fa-clock"></i> Options Expiration</label>
+                </div>
+                <div class="filter-chip">
+                    <input type="checkbox" id="filterHolidays" checked onchange="filterEvents()">
+                    <label for="filterHolidays"><i class="fas fa-flag"></i> Market Holidays</label>
+                </div>
+                <div class="filter-chip">
+                    <input type="checkbox" id="filterHighImpact" onchange="filterEvents()">
+                    <label for="filterHighImpact"><i class="fas fa-fire"></i> High Impact Only</label>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <div id="loadingIndicator" class="text-center py-5" style="display: none;">
+        <div class="spinner-border text-success" role="status">
+            <span class="visually-hidden">Loading…</span>
+        </div>
+        <p class="mt-3">Syncing the latest market intelligence…</p>
     </div>
 
-    <!-- Week Navigation and Filters -->
-    <div class="row mb-4">
-        <div class="col-md-6">
-            <div class="unified-card">
-                <div class="unified-card-header">
-                    <h5><i class="fas fa-calendar"></i> Week Selection</h5>
-                </div>
-                <div class="unified-card-body">
-                    <div class="d-flex align-items-center gap-2">
-                        <button class="btn unified-btn unified-btn-outline btn-sm" onclick="changeWeek(-1)">
-                            <i class="fas fa-chevron-left"></i> Previous Week
-                        </button>
-                        <input type="date" id="weekSelector" class="form-control unified-form-control" onchange="selectWeek()">
-                        <button class="btn unified-btn unified-btn-outline btn-sm" onclick="changeWeek(1)">
-                            Next Week <i class="fas fa-chevron-right"></i>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-6">
-            <div class="unified-card">
-                <div class="unified-card-header">
-                    <h5><i class="fas fa-filter"></i> Event Filters</h5>
-                </div>
-                <div class="unified-card-body">
-                    <div class="row">
-                        <div class="col-6">
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="filterEarnings" checked onchange="filterEvents()">
-                                <label class="form-check-label" for="filterEarnings">
-                                    <span class="badge bg-primary">Earnings</span>
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="filterFed" checked onchange="filterEvents()">
-                                <label class="form-check-label" for="filterFed">
-                                    <span class="badge bg-danger">Fed Events</span>
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="filterEconomic" checked onchange="filterEvents()">
-                                <label class="form-check-label" for="filterEconomic">
-                                    <span class="badge bg-success">Economic Data</span>
-                                </label>
-                            </div>
-                        </div>
-                        <div class="col-6">
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="filterOptions" checked onchange="filterEvents()">
-                                <label class="form-check-label" for="filterOptions">
-                                    <span class="unified-badge warning">Options Exp</span>
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="filterHolidays" checked onchange="filterEvents()">
-                                <label class="form-check-label" for="filterHolidays">
-                                    <span class="badge bg-secondary">Holidays</span>
-                                </label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="filterHighImpact" onchange="filterEvents()">
-                                <label class="form-check-label" for="filterHighImpact">
-                                    High Impact Only
-                                </label>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+    <section class="weekly-calendar-section">
+        <h4>Multi-Week Preview</h4>
+        <div class="weekly-calendar-container" id="weeklyCalendar"></div>
+    </section>
 
-    <!-- Loading Indicator -->
-    <div id="loadingIndicator" class="text-center py-4" style="display: none;">
-        <div class="spinner-border text-primary" role="status">
-            <span class="visually-hidden">Loading...</span>
+    <section>
+        <div class="summary-grid" id="eventSummary">
+            <div class="summary-card">
+                <div class="summary-icon"><i class="fas fa-chart-line"></i></div>
+                <h3 id="earningsCount">0</h3>
+                <p>Earnings Reports</p>
+            </div>
+            <div class="summary-card">
+                <div class="summary-icon"><i class="fas fa-university"></i></div>
+                <h3 id="fedCount">0</h3>
+                <p>Fed &amp; Central Bank Events</p>
+            </div>
+            <div class="summary-card">
+                <div class="summary-icon"><i class="fas fa-chart-bar"></i></div>
+                <h3 id="economicCount">0</h3>
+                <p>Economic Releases</p>
+            </div>
+            <div class="summary-card">
+                <div class="summary-icon"><i class="fas fa-clock"></i></div>
+                <h3 id="optionsCount">0</h3>
+                <p>Options Expirations</p>
+            </div>
         </div>
-        <p class="mt-2">Loading market events...</p>
-    </div>
+    </section>
 
-    <!-- Weekly Calendar View -->
-    <div class="row weekly-calendar-container" id="weeklyCalendar">
-        <!-- Calendar will be populated by JavaScript -->
-    </div>
+    <section>
+        <div class="detailed-events-card">
+            <h5><i class="fas fa-list"></i> Detailed Event Timeline</h5>
+            <div class="table-responsive">
+                <table class="table unified-table align-middle" id="eventsTable">
+                    <thead>
+                        <tr>
+                            <th scope="col">Date</th>
+                            <th scope="col">Day</th>
+                            <th scope="col">Event</th>
+                            <th scope="col">Type</th>
+                            <th scope="col">Impact</th>
+                            <th scope="col">Symbol</th>
+                            <th scope="col">Timing</th>
+                        </tr>
+                    </thead>
+                    <tbody id="eventsTableBody"></tbody>
+                </table>
+            </div>
+        </div>
+    </section>
 
-    <!-- Event Summary Cards -->
-    <div class="row mt-4" id="eventSummary">
-        <div class="col-md-3">
-            <div class="stats-card">
-                <div class="card-body text-center">
-                    <h3 id="earningsCount">0</h3>
-                    <p>Earnings Reports</p>
-                </div>
-            </div>
+    <section id="watchlistEventsRow" style="display: none;">
+        <div class="weekly-card">
+            <h5><i class="fas fa-star"></i> Watchlist Focus</h5>
+            <div id="watchlistEvents"></div>
         </div>
-        <div class="col-md-3">
-            <div class="stats-card">
-                <div class="card-body text-center">
-                    <h3 id="fedCount">0</h3>
-                    <p>Fed Events</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3">
-            <div class="stats-card">
-                <div class="card-body text-center">
-                    <h3 id="economicCount">0</h3>
-                    <p>Economic Releases</p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-3">
-            <div class="stats-card">
-                <div class="card-body text-center">
-                    <h3 id="optionsCount">0</h3>
-                    <p>Options Expirations</p>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Detailed Events List -->
-    <div class="row mt-4">
-        <div class="col-12">
-            <div class="unified-card">
-                <div class="unified-card-header">
-                    <h5><i class="fas fa-list"></i> Detailed Events List</h5>
-                </div>
-                <div class="unified-card-body">
-                    <div class="table-responsive">
-                        <table class="table unified-table" id="eventsTable">
-                            <thead>
-                                <tr>
-                                    <th>Date</th>
-                                    <th>Day</th>
-                                    <th>Event</th>
-                                    <th>Type</th>
-                                    <th>Impact</th>
-                                    <th>Symbol</th>
-                                    <th>Timing</th>
-                                </tr>
-                            </thead>
-                            <tbody id="eventsTableBody">
-                                <!-- Events will be populated by JavaScript -->
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <!-- Watchlist Events (if applicable) -->
-    <div class="row mt-4" id="watchlistEventsRow" style="display: none;">
-        <div class="col-12">
-            <div class="unified-card">
-                <div class="unified-card-header">
-                    <h5><i class="fas fa-star"></i> Your Watchlist Events</h5>
-                </div>
-                <div class="unified-card-body" id="watchlistEvents">
-                    <!-- Watchlist specific events -->
-                </div>
-            </div>
-        </div>
-    </div>
+    </section>
 </div>
 {% endblock %}
 
@@ -184,29 +138,43 @@
 <script>
 let currentWeekStart = new Date();
 let allEvents = {};
+const weeksToRender = 3;
 
 // Initialize the page
-document.addEventListener('DOMContentLoaded', function() {
-    // Set initial week to current week (handle Sunday correctly)
+window.addEventListener('DOMContentLoaded', () => {
     const today = new Date();
     const monday = getMondayForDate(today);
     currentWeekStart = monday;
     document.getElementById('weekSelector').value = formatDate(monday);
-    // Load initial week
+    updateSelectedWeekLabel(monday);
     loadWeeklyEvents();
 });
 
 function formatDate(date) {
-    // Format YYYY-MM-DD in local time to avoid UTC offset issues (esp. Sundays)
     const d = new Date(date);
     const tzAdjusted = new Date(d.getTime() - d.getTimezoneOffset() * 60000);
     return tzAdjusted.toISOString().split('T')[0];
 }
 
+function formatDisplayDate(date) {
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+function formatWeekRange(start, end) {
+    return `${formatDisplayDate(start)} - ${formatDisplayDate(end)}`;
+}
+
+function updateSelectedWeekLabel(startDate) {
+    const start = new Date(startDate);
+    const end = new Date(startDate);
+    end.setDate(end.getDate() + 4);
+    document.getElementById('selectedWeekLabel').textContent = `Week of ${formatDisplayDate(start)} (${formatWeekRange(start, end)})`;
+}
+
 function getCurrentWeekBounds() {
     const start = new Date(currentWeekStart);
     const end = new Date(currentWeekStart);
-    end.setDate(end.getDate() + 6);
+    end.setDate(end.getDate() + 4);
     return { start, end };
 }
 
@@ -222,9 +190,10 @@ function isDateWithinRange(dateStr, startDate, endDate) {
 
 function changeWeek(direction) {
     const newDate = new Date(currentWeekStart);
-    newDate.setDate(newDate.getDate() + (direction * 7));
+    newDate.setDate(newDate.getDate() + direction * 7);
     currentWeekStart = newDate;
     document.getElementById('weekSelector').value = formatDate(newDate);
+    updateSelectedWeekLabel(newDate);
     loadWeeklyEvents();
 }
 
@@ -232,28 +201,24 @@ function selectWeek() {
     const selectedDate = new Date(document.getElementById('weekSelector').value);
     const monday = getMondayForDate(selectedDate);
     currentWeekStart = monday;
-    // Normalize the date input to the computed Monday to avoid off-by-one on Sundays
     document.getElementById('weekSelector').value = formatDate(monday);
+    updateSelectedWeekLabel(monday);
     loadWeeklyEvents();
 }
 
 function loadWeeklyEvents() {
     const loadingIndicator = document.getElementById('loadingIndicator');
     const calendar = document.getElementById('weeklyCalendar');
-    
+
     loadingIndicator.style.display = 'block';
     calendar.style.display = 'none';
-    
-    const weekStart = formatDate(currentWeekStart);
-    
-    const daysBack = 0;
-    const daysAhead = 6;
 
-    fetch(`/api/weekly_events?start_date=${weekStart}&days_back=${daysBack}&days_ahead=${daysAhead}`)
+    const weekStart = formatDate(currentWeekStart);
+
+    fetch(`/api/weekly_events?start_date=${weekStart}&days_back=0&days_ahead=20`)
         .then(response => response.json())
         .then(response => {
-            console.log('API Response:', response); // Debug log
-            allEvents = response.data || response; // Handle both nested and flat structures
+            allEvents = response.data || response;
             renderCalendar();
             updateSummary();
             renderEventsTable();
@@ -263,39 +228,21 @@ function loadWeeklyEvents() {
         .catch(error => {
             console.error('Error loading events:', error);
             loadingIndicator.style.display = 'none';
-            calendar.innerHTML = '<div class="col-12"><div class="alert alert-danger">Failed to load events</div></div>';
+            calendar.innerHTML = '<div class="alert alert-danger">Failed to load events</div>';
             calendar.style.display = 'block';
         });
 }
 
-// Compute Monday for any given date (weekdays only)
 function getMondayForDate(inputDate) {
     const date = new Date(inputDate);
-    const day = date.getDay(); // 0 = Sun, 1 = Mon, ..., 6 = Sat
-    const diff = (day === 0 ? -6 : 1) - day; // If Sunday, go back 6 days; else move to Monday
+    const day = date.getDay();
+    const diff = (day === 0 ? -6 : 1) - day;
     date.setDate(date.getDate() + diff);
     return date;
 }
 
-function renderCalendar() {
-    // Get current filter state
-    const filters = {
-        earnings: document.getElementById('filterEarnings').checked,
-        fed: document.getElementById('filterFed').checked,
-        economic: document.getElementById('filterEconomic').checked,
-        options: document.getElementById('filterOptions').checked,
-        holidays: document.getElementById('filterHolidays').checked,
-        highImpact: document.getElementById('filterHighImpact').checked
-    };
-    
-    // Use the filtered rendering function
-    renderCalendarWithFilters(filters);
-}
-
 function getAllEventsForDate(dateStr) {
     const events = [];
-    
-    // Collect events from all categories (weekdays only)
     ['earnings', 'economic', 'federal_reserve', 'options_expiration', 'market_holidays'].forEach(category => {
         if (allEvents[category]) {
             allEvents[category].forEach(event => {
@@ -305,52 +252,30 @@ function getAllEventsForDate(dateStr) {
             });
         }
     });
-    
     return events;
 }
 
-function truncateText(text, maxLength = 20) {
+function truncateText(text = '', maxLength = 20) {
     if (text.length <= maxLength) return text;
-    return text.substring(0, maxLength - 3) + '...';
+    return text.substring(0, maxLength - 3) + '…';
 }
 
-function renderDayEvents(events, isWeekend = false) {
-    if (events.length === 0) {
-        return '<small class="text-muted">No events</small>';
+function getEventBadgeClass(event) {
+    switch (event.event_type) {
+        case 'earnings':
+            return 'earnings';
+        case 'federal_reserve':
+            return 'fed';
+        case 'economic_data':
+            return 'economic';
+        case 'options_expiration':
+            return 'options';
+        case 'market_holiday':
+        case 'market_holidays':
+            return 'holiday';
+        default:
+            return '';
     }
-    
-    let html = '';
-    events.forEach(event => {
-        const badge = getEventBadge(event);
-        const icon = getEventIcon(event);
-        const eventText = event.name || event.symbol || 'Event';
-        const maxLength = isWeekend ? 15 : 25;
-        const displayText = truncateText(eventText, maxLength);
-        
-        html += `
-            <div class="event-item">
-                <small>
-                    <i class="${icon}"></i>
-                    <span class="${badge}" title="${eventText}">${displayText}</span>
-                </small>
-            </div>
-        `;
-    });
-    
-    return html;
-}
-
-function getEventBadge(event) {
-    const typeMap = {
-        'earnings': 'badge bg-primary',
-        'federal_reserve': 'badge bg-danger',
-        'economic_data': 'badge bg-success',
-        'options_expiration': 'unified-badge warning',
-        'market_holiday': 'badge bg-secondary',
-        'market_holidays': 'badge bg-secondary'
-    };
-    
-    return typeMap[event.event_type] || 'badge bg-info';
 }
 
 function getEventIcon(event) {
@@ -358,96 +283,33 @@ function getEventIcon(event) {
         'earnings': 'fas fa-chart-line',
         'federal_reserve': 'fas fa-university',
         'economic_data': 'fas fa-chart-bar',
-        'options_expiration': 'fas fa-calendar-times',
-        'market_holiday': 'fas fa-calendar-day',
-        'market_holidays': 'fas fa-calendar-day'
+        'options_expiration': 'fas fa-clock',
+        'market_holiday': 'fas fa-flag',
+        'market_holidays': 'fas fa-flag'
     };
-    
     return iconMap[event.event_type] || 'fas fa-calendar';
 }
 
-function updateSummary() {
-    let counts = {
-        earnings: 0,
-        fed: 0,
-        economic: 0,
-        options: 0
-    };
-
-    const { start, end } = getCurrentWeekBounds();
-
-    if (allEvents.earnings) {
-        counts.earnings = allEvents.earnings.filter(event => isDateWithinRange(event.date, start, end)).length;
-    }
-    if (allEvents.federal_reserve) {
-        counts.fed = allEvents.federal_reserve.filter(event => isDateWithinRange(event.date, start, end)).length;
-    }
-    if (allEvents.economic) {
-        counts.economic = allEvents.economic.filter(event => isDateWithinRange(event.date, start, end)).length;
-    }
-    if (allEvents.options_expiration) {
-        counts.options = allEvents.options_expiration.filter(event => isDateWithinRange(event.date, start, end)).length;
+function renderDayEvents(events) {
+    if (!events.length) {
+        return '<span class="no-events">No scheduled catalysts</span>';
     }
 
-    document.getElementById('earningsCount').textContent = counts.earnings;
-    document.getElementById('fedCount').textContent = counts.fed;
-    document.getElementById('economicCount').textContent = counts.economic;
-    document.getElementById('optionsCount').textContent = counts.options;
+    return events.map(event => {
+        const badgeClass = getEventBadgeClass(event);
+        const icon = getEventIcon(event);
+        const eventText = truncateText(event.name || event.symbol || 'Event', 32);
+        return `<span class="event-pill ${badgeClass}"><i class="${icon}"></i>${eventText}</span>`;
+    }).join('');
 }
 
-function renderEventsTable() {
-    const tbody = document.getElementById('eventsTableBody');
-    const allEventsList = [];
-    
-    // Collect all events
-    ['earnings', 'economic', 'federal_reserve', 'options_expiration', 'market_holidays'].forEach(category => {
-        if (allEvents[category]) {
-            allEvents[category].forEach(event => {
-                allEventsList.push(event);
-            });
-        }
-    });
-
-    const { start, end } = getCurrentWeekBounds();
-    const weeklyEvents = allEventsList.filter(event => isDateWithinRange(event.date, start, end));
-
-    // Sort by date
-    weeklyEvents.sort((a, b) => parseDateString(a.date) - parseDateString(b.date));
-
-    let html = '';
-    weeklyEvents.forEach(event => {
-        // Parse date as local time to avoid timezone offset issues
-        const date = parseDateString(event.date);
-        const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
-        const formattedDate = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-
-        html += `
-            <tr class="event-row" data-type="${event.event_type}" data-impact="${event.impact}">
-                <td>${formattedDate}</td>
-                <td>${dayName}</td>
-                <td>${event.name || event.symbol}</td>
-                <td><span class="${getEventBadge(event)}">${event.event_type.replace('_', ' ')}</span></td>
-                <td><span class="badge bg-${getImpactColor(event.impact)}">${event.impact}</span></td>
-                <td>${event.symbol || '-'}</td>
-                <td>${event.timing || '-'}</td>
-            </tr>
-        `;
-    });
-    
-    tbody.innerHTML = html;
+function renderCalendar() {
+    const filters = getActiveFilters();
+    renderCalendarWithFilters(filters);
 }
 
-function getImpactColor(impact) {
-    const colorMap = {
-        'high': 'danger',
-        'medium': 'warning',
-        'low': 'info'
-    };
-    return colorMap[impact] || 'secondary';
-}
-
-function filterEvents() {
-    const filters = {
+function getActiveFilters() {
+    return {
         earnings: document.getElementById('filterEarnings').checked,
         fed: document.getElementById('filterFed').checked,
         economic: document.getElementById('filterEconomic').checked,
@@ -455,95 +317,211 @@ function filterEvents() {
         holidays: document.getElementById('filterHolidays').checked,
         highImpact: document.getElementById('filterHighImpact').checked
     };
-    
+}
+
+function getFilteredEventsForDate(dateStr, filters) {
+    const events = getAllEventsForDate(dateStr);
+    return events.filter(event => {
+        let show = false;
+        if (event.event_type === 'earnings' && filters.earnings) show = true;
+        if (event.event_type === 'federal_reserve' && filters.fed) show = true;
+        if (event.event_type === 'economic_data' && filters.economic) show = true;
+        if (event.event_type === 'options_expiration' && filters.options) show = true;
+        if ((event.event_type === 'market_holidays' || event.event_type === 'market_holiday') && filters.holidays) show = true;
+        if (filters.highImpact && event.impact !== 'high') show = false;
+        return show;
+    });
+}
+
+function buildWeekMetrics(events) {
+    const metrics = {
+        total: events.length,
+        earnings: 0,
+        fed: 0,
+        economic: 0,
+        options: 0
+    };
+
+    events.forEach(event => {
+        if (event.event_type === 'earnings') metrics.earnings += 1;
+        if (event.event_type === 'federal_reserve') metrics.fed += 1;
+        if (event.event_type === 'economic_data') metrics.economic += 1;
+        if (event.event_type === 'options_expiration') metrics.options += 1;
+    });
+
+    return metrics;
+}
+
+function renderCalendarWithFilters(filters) {
+    const calendar = document.getElementById('weeklyCalendar');
+    const parts = [];
+
+    for (let week = 0; week < weeksToRender; week++) {
+        const weekStart = new Date(currentWeekStart);
+        weekStart.setDate(weekStart.getDate() + week * 7);
+        const weekEnd = new Date(weekStart);
+        weekEnd.setDate(weekEnd.getDate() + 4);
+
+        let weeklyEvents = [];
+        let dayCards = '';
+
+        for (let i = 0; i < 5; i++) {
+            const date = new Date(weekStart);
+            date.setDate(date.getDate() + i);
+            const dateStr = formatDate(date);
+            const dayEvents = getFilteredEventsForDate(dateStr, filters);
+            const isToday = dateStr === formatDate(new Date());
+
+            weeklyEvents = weeklyEvents.concat(dayEvents);
+
+            const dayHasEvents = dayEvents.length > 0;
+            const dayClasses = ['day-card'];
+            if (isToday) dayClasses.push('is-today');
+            if (dayHasEvents) dayClasses.push('has-events');
+
+            dayCards += `
+                <div class="${dayClasses.join(' ')}">
+                    <div class="day-header">
+                        <span class="day-name">${date.toLocaleDateString('en-US', { weekday: 'short' })}</span>
+                        <span class="day-date">${date.getMonth() + 1}/${date.getDate()}</span>
+                    </div>
+                    <div class="day-events">${renderDayEvents(dayEvents)}</div>
+                </div>
+            `;
+        }
+
+        const metrics = buildWeekMetrics(weeklyEvents);
+
+        parts.push(`
+            <div class="week-module">
+                <div class="week-module-header">
+                    <div class="week-label">
+                        <span class="title">Week ${week + 1}</span>
+                        <span class="range">${formatWeekRange(weekStart, weekEnd)}</span>
+                    </div>
+                    <div class="week-total"><i class="fas fa-bolt"></i> ${metrics.total}<span>Events</span></div>
+                </div>
+                <div class="weekly-metrics">
+                    <div class="week-metric">
+                        <span class="metric-icon"><i class="fas fa-chart-line"></i></span>
+                        <span class="metric-label">Earnings</span>
+                        <span class="metric-value">${metrics.earnings}</span>
+                    </div>
+                    <div class="week-metric">
+                        <span class="metric-icon"><i class="fas fa-university"></i></span>
+                        <span class="metric-label">Fed Events</span>
+                        <span class="metric-value">${metrics.fed}</span>
+                    </div>
+                    <div class="week-metric">
+                        <span class="metric-icon"><i class="fas fa-chart-bar"></i></span>
+                        <span class="metric-label">Economic</span>
+                        <span class="metric-value">${metrics.economic}</span>
+                    </div>
+                    <div class="week-metric">
+                        <span class="metric-icon"><i class="fas fa-clock"></i></span>
+                        <span class="metric-label">Options Exp.</span>
+                        <span class="metric-value">${metrics.options}</span>
+                    </div>
+                </div>
+                <div class="week-grid">${dayCards}</div>
+            </div>
+        `);
+    }
+
+    calendar.innerHTML = parts.join('');
+}
+
+function updateSummary() {
+    const filters = getActiveFilters();
+    const { start } = getCurrentWeekBounds();
+    let earnings = 0;
+    let fed = 0;
+    let economic = 0;
+    let options = 0;
+
+    for (let i = 0; i < 5; i++) {
+        const date = new Date(start);
+        date.setDate(start.getDate() + i);
+        const dateStr = formatDate(date);
+        const dayEvents = getFilteredEventsForDate(dateStr, filters);
+        dayEvents.forEach(event => {
+            if (event.event_type === 'earnings') earnings += 1;
+            if (event.event_type === 'federal_reserve') fed += 1;
+            if (event.event_type === 'economic_data') economic += 1;
+            if (event.event_type === 'options_expiration') options += 1;
+        });
+    }
+
+    document.getElementById('earningsCount').textContent = earnings;
+    document.getElementById('fedCount').textContent = fed;
+    document.getElementById('economicCount').textContent = economic;
+    document.getElementById('optionsCount').textContent = options;
+}
+
+function renderEventsTable() {
+    const tbody = document.getElementById('eventsTableBody');
+    const filters = getActiveFilters();
+    const allEventsList = [];
+
+    ['earnings', 'economic', 'federal_reserve', 'options_expiration', 'market_holidays'].forEach(category => {
+        if (allEvents[category]) {
+            allEvents[category].forEach(event => allEventsList.push(event));
+        }
+    });
+
+    const { start, end } = getCurrentWeekBounds();
+    const weeklyEvents = allEventsList.filter(event => isDateWithinRange(event.date, start, end));
+
+    weeklyEvents.sort((a, b) => parseDateString(a.date) - parseDateString(b.date));
+
+    const rows = weeklyEvents.map(event => {
+        const filtered = getFilteredEventsForDate(event.date, filters);
+        const shouldDisplay = filtered.includes(event);
+        const date = parseDateString(event.date);
+        const dayName = date.toLocaleDateString('en-US', { weekday: 'short' });
+        const formattedDate = formatDisplayDate(date);
+        const typeClass = getEventBadgeClass(event);
+        const impactClass = (event.impact || 'low').toLowerCase();
+        return `
+            <tr class="event-row" data-type="${event.event_type}" data-impact="${event.impact || ''}" style="display:${shouldDisplay ? '' : 'none'};">
+                <td>${formattedDate}</td>
+                <td>${dayName}</td>
+                <td>${event.name || event.symbol || 'Event'}</td>
+                <td><span class="type-pill ${typeClass}"><i class="${getEventIcon(event)}"></i>${(event.event_type || '').replace('_', ' ')}</span></td>
+                <td><span class="impact-pill ${impactClass}">${event.impact || 'n/a'}</span></td>
+                <td>${event.symbol || '-'}</td>
+                <td>${event.timing || '-'}</td>
+            </tr>
+        `;
+    });
+
+    tbody.innerHTML = rows.join('');
+}
+
+function filterEvents() {
+    const filters = getActiveFilters();
     const rows = document.querySelectorAll('.event-row');
-    
+
     rows.forEach(row => {
         const type = row.dataset.type;
-        const impact = row.dataset.impact;
-        
+        const impact = (row.dataset.impact || '').toLowerCase();
         let show = false;
-        
-        // Check type filters - match actual event_type values from API
+
         if (type === 'earnings' && filters.earnings) show = true;
         if (type === 'federal_reserve' && filters.fed) show = true;
         if (type === 'economic_data' && filters.economic) show = true;
         if (type === 'options_expiration' && filters.options) show = true;
         if ((type === 'market_holidays' || type === 'market_holiday') && filters.holidays) show = true;
-        
-        // Apply high impact filter
+
         if (filters.highImpact && impact !== 'high') show = false;
-        
+
         row.style.display = show ? '' : 'none';
     });
-    
-    // Also apply filters to calendar view
+
     renderCalendarWithFilters(filters);
+    updateSummary();
 }
 
-function renderCalendarWithFilters(filters) {
-    const calendar = document.getElementById('weeklyCalendar');
-    const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'];
-    
-    let calendarHTML = '';
-    
-    // Show 4 weeks (month view)
-    for (let week = 0; week < 4; week++) {
-        const weekStart = new Date(currentWeekStart);
-        weekStart.setDate(weekStart.getDate() + (week * 7));
-        const weekEnd = new Date(weekStart);
-        weekEnd.setDate(weekEnd.getDate() + 4);
-        
-        calendarHTML += `<div class="col-12 mb-3"><h5 class="text-center text-muted">Week ${week + 1}: ${formatDate(weekStart)} - ${formatDate(weekEnd)}</h5></div>`;
-        
-        for (let i = 0; i < 5; i++) {
-            const date = new Date(weekStart);
-            date.setDate(date.getDate() + i);
-            const dateStr = formatDate(date);
-            const dayName = days[i];
-            const dayEvents = getFilteredEventsForDate(dateStr, filters);
-            const isToday = dateStr === formatDate(new Date());
-            
-            calendarHTML += `
-                <div class="col weekly-day-column">
-                    <div class="card weekly-calendar-card ${isToday ? 'border-primary' : ''}">
-                        <div class="card-header text-center ${isToday ? 'bg-primary text-white' : ''}">
-                            <h6 class="mb-0">${dayName}</h6>
-                            <small>${date.getMonth() + 1}/${date.getDate()}</small>
-                        </div>
-                        <div class="card-body">
-                            ${renderDayEvents(dayEvents, false)}
-                        </div>
-                    </div>
-                </div>
-            `;
-        }
-    }
-    
-    calendar.innerHTML = calendarHTML;
-}
-
-function getFilteredEventsForDate(dateStr, filters) {
-    const events = getAllEventsForDate(dateStr);
-    
-    return events.filter(event => {
-        // Apply type filters
-        let showByType = false;
-        
-        if (event.event_type === 'earnings' && filters.earnings) showByType = true;
-        if (event.event_type === 'federal_reserve' && filters.fed) showByType = true;
-        if (event.event_type === 'economic_data' && filters.economic) showByType = true;
-        if (event.event_type === 'options_expiration' && filters.options) showByType = true;
-        if ((event.event_type === 'market_holidays' || event.event_type === 'market_holiday') && filters.holidays) showByType = true;
-        
-        // Apply high impact filter
-        if (filters.highImpact && event.impact !== 'high') showByType = false;
-        
-        return showByType;
-    });
-}
-
-// Export functions for global access
 window.changeWeek = changeWeek;
 window.selectWeek = selectWeek;
 window.filterEvents = filterEvents;


### PR DESCRIPTION
## Summary
- redesign the weekly plan template with a hero banner, chip-style filters, multi-week cards, and refreshed tables to mirror the latest UI mock
- add a dedicated `weekly_plan.css` stylesheet that defines gradients, chips, event pills, and responsive behavior for the new layout
- enhance the page script to drive the new markup, including multi-week metrics, filtered summaries, and improved calendar rendering

## Testing
- pytest test_real_command.py

------
https://chatgpt.com/codex/tasks/task_e_68d48d1ea9d4832aa2604737389bb948