### PR TITLE
Style weekly plan card headers with hero gradient

### DIFF
--- a/src/web/static/css/weekly_plan.css
+++ b/src/web/static/css/weekly_plan.css
@@ -16,6 +16,23 @@
     --weekly-badge-holiday: linear-gradient(135deg, rgba(142, 142, 164, 0.9), rgba(96, 96, 112, 0.7));
 }
 
+.weekly-plan-page .card-header {
+    background: var(--bg-header);
+    border-bottom: 1px solid var(--border-accent);
+    color: var(--text-primary);
+    box-shadow: 0 12px 28px rgba(0, 255, 136, 0.12);
+}
+
+.weekly-plan-page .card-header h5,
+.weekly-plan-page .card-header h6 {
+    color: inherit;
+}
+
+.weekly-plan-page .card-header i {
+    color: var(--primary-color);
+    filter: drop-shadow(0 0 6px rgba(0, 255, 136, 0.25));
+}
+
 .weekly-plan-wrapper {
     display: flex;
     flex-direction: column;

--- a/src/web/templates/weekly_plan.html
+++ b/src/web/templates/weekly_plan.html
@@ -2,8 +2,14 @@
 
 {% block title %}Weekly Market Plan - Trading AI{% endblock %}
 
+{% block extra_head %}
+    {{ super() }}
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/unified_theme.css') }}?v=5">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/weekly_plan.css') }}?v=2">
+{% endblock %}
+
 {% block content %}
-<link rel="stylesheet" href="{{ url_for('static', filename='css/unified_theme.css') }}?v=5">
+<div class="weekly-plan-page">
 <div class="container-fluid">
     <div class="row mb-4">
         <div class="col-12">
@@ -178,6 +184,7 @@
             </div>
         </div>
     </div>
+</div>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- load the weekly plan page-specific stylesheet alongside the unified theme assets
- scope the weekly plan layout with a container for page-specific styling hooks
- restyle weekly plan card headers to use the neon green gradient header treatment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4c379a460832ab34fd45b9bfcc8db