### PR TITLE
Rebuild scalping style kit with neon grid aesthetic

### DIFF
--- a/docs/style-guide/global-style-recommendations.md
+++ b/docs/style-guide/global-style-recommendations.md
@@ -1,0 +1,64 @@
+# Scalping Signals Atmosphere · Global Stylesheet Guidance
+
+You asked for the rest of the experience to feel like the live `/scalping_signals` page. The refreshed `scalping-global.css` distills that look — midnight gradients, cyan gridlines, glass cards, and neon CTAs — into a single drop-in layer. Pair it with Font Awesome (for icons) and you can mock any view without rebuilding chrome.
+
+## 1. Include These Assets
+
+```html
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-GL3FZmWfP7HQP9PL8uEjzsv+VKYQHzNmgP8lR+W3qIx2P2+41sJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZ1sA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="scalping-global.css">
+```
+
+Bootstrap is no longer required — the stylesheet ships responsive grids, cards, tables, and form treatments purpose-built for the scalping palette.
+
+## 2. Palette, Light, and Texture
+
+The CSS recreates the screenshot’s vibe through layered backgrounds and trace lines:
+
+- **Backdrops**: deep charcoal gradients (`#040405` → `#0c1118`) plus subtle radial beams in cyan and violet.
+- **Grid Overlay**: repeating linear gradients render the faint cyan lattice seen on the real scalping canvas.
+- **Type**: Inter + Space Grotesk with wide tracking, matching the confident trading typography.
+- **Accents**: Cyan (`#3df6ff`) and emerald (`#38f59d`) gradients for primary CTAs, with purple and amber for contextual tags.
+
+## 3. Core Building Blocks
+
+| Use case | Classes | What they mirror from `/scalping_signals` |
+| --- | --- | --- |
+| Page chrome | `.page`, `.nav-bar`, `.nav-brand`, `.nav-links` | Frosted nav bar with neon logo tile and underline hover effect. |
+| Hero surfaces | `.hero`, `.hero-copy`, `.hero-aside`, `.glow-box` | Hover-reactive hero with cyan beams, badge ribbons, and KPI pods. |
+| Calls to action | `.btn-primary`, `.btn-ghost`, `.button-row` | Cyan-to-green gradient buttons and glass-outline alternates. |
+| Stats | `.metric-grid`, `.metric`, `.utility-grid`, `.stat` | KPI tiles and quick stats with mono labels and glow borders. |
+| Content panels | `.panel`, `.panel-header`, `.panel-title`, `.panel-tag` | Glass cards with icon tiles, neon edge, and hover sheen. |
+| Lists & tags | `.bullet-list`, `.dot`, `.tag-group`, `.tag` | Dot list and tokenized specialties in the scalping badge style. |
+| Tables | `.table-wrapper`, `table`, `.status-chip` | Dense telemetry tables with cyan dividers and status pills. |
+| Timelines | `.timeline`, `.timeline-item` | Vertical signal traces with halo markers for ops history. |
+| Testimonials | `.testimonial` | Soft blur cards for quotes or analyst callouts. |
+| Forms | `.contact-card`, `.form-grid`, `.info-line`, `input`, `select`, `textarea` | Mission-control intake with neon focus outlines and glass info rows. |
+
+## 4. Layout System
+
+- `.page` constrains content to ~1180px while keeping generous breathing room.
+- `.section` spaces vertical bands so each module gets its own neon glow.
+- `.grid-2` and `.grid-3` provide responsive splits (stacking under 720px).
+- `.metric-grid` auto-fills KPI cards; `.utility-grid` handles quick stats.
+- `.button-row` keeps CTAs evenly spaced and wraps on small screens.
+
+## 5. Interaction Rules
+
+1. Keep CTAs inside `.btn-primary` or `.btn-ghost` so the gradients match the screenshot.
+2. Wrap copy-heavy blocks in `.panel` to inherit the glass sheen and hover highlight.
+3. Use `.status-chip` variants (`.success`, `.warning`, `.danger`) for runbook and compliance states — they carry the neon halo effect.
+4. For sequences or ops notes, `.timeline` aligns to the same cyan spine the scalping UI uses for event trails.
+5. Forms sit inside `.contact-card` to maintain blur, halo borders, and consistent label tracking.
+
+## 6. Sample Views
+
+The `/docs/style-guide/samples` folder includes five HTML files wired to the refreshed stylesheet:
+
+1. **Landing** — marketing hero with KPI pods and service panels that echo the screenshot’s hero.
+2. **Dashboard** — telemetry stats, signal cards, timelines, and venue table styled like the live console.
+3. **Market Report** — editorial layout with highlights, AI commentary, and KPI table.
+4. **Team** — roster panels, avatar halos, and culture testimonials inside glass cards.
+5. **Contact** — neon intake form and support touchpoints within a frosted panel.
+
+Open them in a browser and the background, gridlines, glows, and buttons all align with the scalping reference image while covering the major AI consulting page types.

--- a/docs/style-guide/samples/contact.html
+++ b/docs/style-guide/samples/contact.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trading AI Consulting · Contact Sample</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-GL3FZmWfP7HQP9PL8uEjzsv+VKYQHzNmgP8lR+W3qIx2P2+41sJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZ1sA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../scalping-global.css">
+</head>
+<body>
+    <main class="page">
+        <nav class="nav-bar">
+            <span class="nav-brand">
+                <span class="mark"><i class="fas fa-headset"></i></span>
+                Neon Contact Center
+            </span>
+            <div class="nav-links">
+                <a href="#">Support</a>
+                <a href="#">Workshops</a>
+                <a href="#">Security</a>
+                <a href="#">Status</a>
+            </div>
+        </nav>
+
+        <section class="section contact-card">
+            <div>
+                <span class="section-kicker"><i class="fas fa-satellite"></i> Touchpoints</span>
+                <h2>Reach the scalping crew in a setting that feels like the trading floor.</h2>
+                <p class="text-muted">The global stylesheet covers contact flows with the same midnight gradients, cyan trace lines, and glowing chips from the console. Even forms feel like mission control.</p>
+
+                <div class="info-line">
+                    <i class="fas fa-message"></i>
+                    <div>
+                        <strong>Signal Hotline</strong>
+                        <p class="text-muted">24/7 neon bridge to traders and AI ops.</p>
+                    </div>
+                </div>
+                <div class="info-line">
+                    <i class="fas fa-calendar-check"></i>
+                    <div>
+                        <strong>Book a Workshop</strong>
+                        <p class="text-muted">90-minute styling deep dives with the delivery team.</p>
+                    </div>
+                </div>
+                <div class="info-line">
+                    <i class="fas fa-user-shield"></i>
+                    <div>
+                        <strong>Security Escalations</strong>
+                        <p class="text-muted">Route sensitive incidents with escalator-level urgency.</p>
+                    </div>
+                </div>
+            </div>
+
+            <form class="form-grid">
+                <div>
+                    <label for="name">Name</label>
+                    <input type="text" id="name" placeholder="Your full name">
+                </div>
+                <div>
+                    <label for="email">Email</label>
+                    <input type="email" id="email" placeholder="you@tradingdesk.com">
+                </div>
+                <div>
+                    <label for="topic">Topic</label>
+                    <select id="topic">
+                        <option>Signal Readiness Review</option>
+                        <option>Design System Pairing</option>
+                        <option>Compliance Workshop</option>
+                        <option>Custom Request</option>
+                    </select>
+                </div>
+                <div>
+                    <label for="message">Message</label>
+                    <textarea id="message" placeholder="How can we support your scalping initiative?"></textarea>
+                </div>
+                <div class="button-row">
+                    <button type="submit" class="btn-primary"><i class="fas fa-paper-plane"></i>Launch Message</button>
+                    <a class="btn-ghost" href="#"><i class="fas fa-headset"></i>Request Call</a>
+                </div>
+            </form>
+        </section>
+    </main>
+</body>
+</html>

--- a/docs/style-guide/samples/dashboard.html
+++ b/docs/style-guide/samples/dashboard.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trading AI Consulting · Dashboard Sample</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-GL3FZmWfP7HQP9PL8uEjzsv+VKYQHzNmgP8lR+W3qIx2P2+41sJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZ1sA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../scalping-global.css">
+</head>
+<body>
+    <main class="page">
+        <nav class="nav-bar">
+            <span class="nav-brand">
+                <span class="mark"><i class="fas fa-brain"></i></span>
+                Signal Ops Hub
+            </span>
+            <div class="nav-links">
+                <a href="#">Streams</a>
+                <a href="#">Models</a>
+                <a href="#">Runbooks</a>
+                <a href="#">Escalations</a>
+            </div>
+        </nav>
+
+        <section class="section">
+            <div class="section-header">
+                <span class="section-kicker"><i class="fas fa-gauge-high"></i> Console Overview</span>
+                <h2>Control the same scalping telemetry from any consulting demo.</h2>
+                <p class="text-muted">This dashboard mock stitches together the neon grid, glass cards, and glow tables that define our scalping signals UI. Drop in your own numbers without touching layout or chroma.</p>
+            </div>
+
+            <div class="utility-grid">
+                <div class="stat">
+                    <span class="text-muted">Latency</span>
+                    <strong>0.21s</strong>
+                    <p>Mean refresh across L2 venues last 5 minutes.</p>
+                </div>
+                <div class="stat">
+                    <span class="text-muted">Signals</span>
+                    <strong>128</strong>
+                    <p>Active scalps under LLM-assisted monitoring.</p>
+                </div>
+                <div class="stat">
+                    <span class="text-muted">Confidence</span>
+                    <strong>94%</strong>
+                    <p>Backtest alignment with live executions.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section grid-2">
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-wave-square"></i></span>
+                        <div>
+                            <h3>Signal Bursts</h3>
+                            <p class="text-muted">LLM flag summaries highlight the hottest micro-trends.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Live</span>
+                </div>
+                <ul class="bullet-list">
+                    <li><span class="dot"></span><span><strong>Asia FX</strong> · Yen liquidity spike triggers volatility dampener with 86% confidence.</span></li>
+                    <li><span class="dot"></span><span><strong>Energy Futures</strong> · LLM oversight caps leverage to 3x after streak of green candles.</span></li>
+                    <li><span class="dot"></span><span><strong>Crypto Spot</strong> · Cross-venue arbitrage stabilized; mark status chip to "contained".</span></li>
+                </ul>
+            </article>
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-list-check"></i></span>
+                        <div>
+                            <h3>Ops Timeline</h3>
+                            <p class="text-muted">Trace escalations with the same cyan vertical spine.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Runbook</span>
+                </div>
+                <div class="timeline">
+                    <div class="timeline-item">
+                        <time>02:14 utc</time>
+                        <p><strong>Model retrain</strong> triggered after drift threshold crossed. New weights deployed to sandbox.</p>
+                    </div>
+                    <div class="timeline-item">
+                        <time>03:02 utc</time>
+                        <p><strong>Compliance sweep</strong> auto-ran across prompts referencing restricted tickers.</p>
+                    </div>
+                    <div class="timeline-item">
+                        <time>03:26 utc</time>
+                        <p><strong>Ops review</strong> captured in transcript and broadcast to the neon contact center.</p>
+                    </div>
+                </div>
+            </article>
+        </section>
+
+        <section class="section">
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-table"></i></span>
+                        <div>
+                            <h3>Venue Snapshot</h3>
+                            <p class="text-muted">Tables stay loyal to the scalping colorway and density.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Telemetry</span>
+                </div>
+                <div class="table-wrapper">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Venue</th>
+                                <th>Latency</th>
+                                <th>Fill Rate</th>
+                                <th>Risk</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>NYSE ARCA</td>
+                                <td>182 ms</td>
+                                <td>97%</td>
+                                <td><span class="text-muted">LLM Guard</span></td>
+                                <td><span class="status-chip success"><i class="fas fa-circle"></i> stable</span></td>
+                            </tr>
+                            <tr>
+                                <td>CME Futures</td>
+                                <td>241 ms</td>
+                                <td>93%</td>
+                                <td><span class="text-muted">Manual Watch</span></td>
+                                <td><span class="status-chip warning"><i class="fas fa-circle"></i> watch</span></td>
+                            </tr>
+                            <tr>
+                                <td>Binance Spot</td>
+                                <td>158 ms</td>
+                                <td>99%</td>
+                                <td><span class="text-muted">LLM Guard</span></td>
+                                <td><span class="status-chip success"><i class="fas fa-circle"></i> stable</span></td>
+                            </tr>
+                            <tr>
+                                <td>Chi-X Europe</td>
+                                <td>302 ms</td>
+                                <td>88%</td>
+                                <td><span class="text-muted">Ops Desk</span></td>
+                                <td><span class="status-chip danger"><i class="fas fa-circle"></i> action</span></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </article>
+        </section>
+    </main>
+</body>
+</html>

--- a/docs/style-guide/samples/landing.html
+++ b/docs/style-guide/samples/landing.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trading AI Consulting · Landing</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-GL3FZmWfP7HQP9PL8uEjzsv+VKYQHzNmgP8lR+W3qIx2P2+41sJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZ1sA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../scalping-global.css">
+</head>
+<body>
+    <main class="page">
+        <nav class="nav-bar">
+            <span class="nav-brand">
+                <span class="mark"><i class="fas fa-wave-square"></i></span>
+                Scalping Systems Lab
+            </span>
+            <div class="nav-links">
+                <a href="#">Capabilities</a>
+                <a href="#">Work</a>
+                <a href="#">Insights</a>
+                <a href="#">Contact</a>
+            </div>
+        </nav>
+
+        <header class="hero section">
+            <div class="hero-copy">
+                <span class="section-kicker"><i class="fas fa-signal"></i> Neon Scalping DNA</span>
+                <h1>Rapid-fire AI consulting with the exact sheen of our live scalping console.</h1>
+                <p class="lead">Every screen borrows the midnight glass, cyan trace lines, and confident typography from the production scalping experience. We package it into a global system you can apply across pitch decks, portals, and ops dashboards.</p>
+                <div class="button-row">
+                    <a class="btn-primary" href="#"><i class="fas fa-bolt"></i>Book a Lightning Audit</a>
+                    <a class="btn-ghost" href="#"><i class="fas fa-file-arrow-down"></i>Download Style Spec</a>
+                </div>
+                <div class="metric-grid">
+                    <div class="metric">
+                        <span>Refresh Cycle</span>
+                        <strong>210 ms</strong>
+                        <p class="text-muted">Latency tolerance showcased in every demo card.</p>
+                    </div>
+                    <div class="metric">
+                        <span>Venues Wired</span>
+                        <strong>42</strong>
+                        <p class="text-muted">Glowing grid references each venue class for instant trust.</p>
+                    </div>
+                    <div class="metric">
+                        <span>Audit Coverage</span>
+                        <strong>98%</strong>
+                        <p class="text-muted">Governance statuses surface with neon chips and badges.</p>
+                    </div>
+                </div>
+            </div>
+            <aside class="hero-aside">
+                <div class="glow-box">
+                    <i class="fas fa-chart-line"></i>
+                    <div>
+                        <strong>Signal Storyboards</strong>
+                        <p class="text-muted">Pre-built hero sequences mirroring the scalping home.</p>
+                    </div>
+                </div>
+                <div class="glow-box">
+                    <i class="fas fa-layer-group"></i>
+                    <div>
+                        <strong>Reusable Tokens</strong>
+                        <p class="text-muted">Color, spacing, and blur tokens sync with production CSS.</p>
+                    </div>
+                </div>
+                <div class="glow-box">
+                    <i class="fas fa-bolt"></i>
+                    <div>
+                        <strong>Launch in Days</strong>
+                        <p class="text-muted">Drop-in HTML kits let teams ship preview sites overnight.</p>
+                    </div>
+                </div>
+            </aside>
+        </header>
+
+        <section class="section">
+            <div class="section-header">
+                <span class="section-kicker"><i class="fas fa-compass-drafting"></i> What You Get</span>
+                <h2>Every touchpoint inherits the same neon precision.</h2>
+                <p>Our global stylesheet recreates the scalping atmosphere with layered gradients, glass panels, and trace-line grids. Mix and match sections to land your narrative without hand-coding UI chrome.</p>
+            </div>
+            <div class="grid-3">
+                <article class="panel">
+                    <div class="panel-header">
+                        <div class="panel-title">
+                            <span class="icon"><i class="fas fa-wand-magic-sparkles"></i></span>
+                            <div>
+                                <h3>Hero Systems</h3>
+                                <p class="text-muted">Badge ribbons, gradient headings, and confident CTAs.</p>
+                            </div>
+                        </div>
+                        <span class="panel-tag">Pitch</span>
+                    </div>
+                    <ul class="bullet-list">
+                        <li><span class="dot"></span><span>Radial glow overlays that match the scalping launch screen.</span></li>
+                        <li><span class="dot"></span><span>Grid-locked metric pods for latency, venues, and coverage.</span></li>
+                        <li><span class="dot"></span><span>Button treatments with cyan to green ramps for action bias.</span></li>
+                    </ul>
+                </article>
+                <article class="panel">
+                    <div class="panel-header">
+                        <div class="panel-title">
+                            <span class="icon"><i class="fas fa-gauge-high"></i></span>
+                            <div>
+                                <h3>Dashboard Chrome</h3>
+                                <p class="text-muted">Cards, tables, and status chips reusing prod-level tokens.</p>
+                            </div>
+                        </div>
+                        <span class="panel-tag">Ops</span>
+                    </div>
+                    <ul class="bullet-list">
+                        <li><span class="dot"></span><span>Glass cards with cyan outlines and faint beam overlays.</span></li>
+                        <li><span class="dot"></span><span>Signal tables with column dividers and neon status chips.</span></li>
+                        <li><span class="dot"></span><span>Timeline components replicating runbook callouts.</span></li>
+                    </ul>
+                </article>
+                <article class="panel">
+                    <div class="panel-header">
+                        <div class="panel-title">
+                            <span class="icon"><i class="fas fa-shield-check"></i></span>
+                            <div>
+                                <h3>Governance Touches</h3>
+                                <p class="text-muted">LLM compliance and audit sections styled like trading logs.</p>
+                            </div>
+                        </div>
+                        <span class="panel-tag">Trust</span>
+                    </div>
+                    <ul class="bullet-list">
+                        <li><span class="dot"></span><span>Badges for review state: success, warning, danger variations.</span></li>
+                        <li><span class="dot"></span><span>Timeline anchors with cyan trace and soft glow halos.</span></li>
+                        <li><span class="dot"></span><span>Tokenized typography for policy copy and disclaimers.</span></li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <footer class="footer">
+            <h3>Drop this stylesheet into your sandbox to feel like the scalping app day one.</h3>
+            <p class="text-muted">The samples in this folder map 1:1 to landing, dashboard, reporting, team, and contact experiences. Customize the copy and feed your data — the vibe holds.</p>
+            <div class="button-row" style="justify-content: center;">
+                <a class="btn-primary" href="#"><i class="fas fa-cloud-arrow-down"></i>Grab the Kit</a>
+                <a class="btn-ghost" href="#"><i class="fas fa-envelope"></i>Talk to Delivery</a>
+            </div>
+        </footer>
+    </main>
+</body>
+</html>

--- a/docs/style-guide/samples/market-report.html
+++ b/docs/style-guide/samples/market-report.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trading AI Consulting · Market Report Sample</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-GL3FZmWfP7HQP9PL8uEjzsv+VKYQHzNmgP8lR+W3qIx2P2+41sJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZ1sA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../scalping-global.css">
+</head>
+<body>
+    <main class="page">
+        <nav class="nav-bar">
+            <span class="nav-brand">
+                <span class="mark"><i class="fas fa-chart-line"></i></span>
+                Neon Flow Weekly
+            </span>
+            <div class="nav-links">
+                <a href="#">Overview</a>
+                <a href="#">Signals</a>
+                <a href="#">LLM Notes</a>
+                <a href="#">Archive</a>
+            </div>
+        </nav>
+
+        <header class="hero section">
+            <div class="hero-copy">
+                <span class="section-kicker"><i class="fas fa-chart-pie"></i> Report Preview</span>
+                <h1>Scalping-fluent reporting with neon headlines and glass data panes.</h1>
+                <p class="lead">The global sheet keeps reports aligned with the console — luminous headline blocks, cyan dividers, and mono captions that spotlight machine co-pilots. Swap the copy and export as PDF or live HTML.</p>
+                <div class="button-row">
+                    <a class="btn-primary" href="#"><i class="fas fa-cloud-arrow-down"></i>Download PDF</a>
+                    <a class="btn-ghost" href="#"><i class="fas fa-share-nodes"></i>Share Live Link</a>
+                </div>
+            </div>
+            <aside class="hero-aside">
+                <div class="glow-box">
+                    <i class="fas fa-bolt"></i>
+                    <div>
+                        <strong>Signal Pulse</strong>
+                        <p class="text-muted">3-day trend overlays highlight emergent microstructure themes.</p>
+                    </div>
+                </div>
+                <div class="glow-box">
+                    <i class="fas fa-database"></i>
+                    <div>
+                        <strong>Data Provenance</strong>
+                        <p class="text-muted">LLM annotations detail which feeds each highlight references.</p>
+                    </div>
+                </div>
+            </aside>
+        </header>
+
+        <section class="section grid-2">
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-arrow-trend-up"></i></span>
+                        <div>
+                            <h3>Market Highlights</h3>
+                            <p class="text-muted">Sparkline narratives use cyan trace to echo scalping UI.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Signals</span>
+                </div>
+                <ul class="bullet-list">
+                    <li><span class="dot"></span><span><strong>Equities</strong> · Mega-cap rotation resumed with LLM confirmation on volume divergence.</span></li>
+                    <li><span class="dot"></span><span><strong>Commodities</strong> · Copper futures triggered a proactive hedge as macro bots flagged inventory stress.</span></li>
+                    <li><span class="dot"></span><span><strong>Crypto</strong> · Neon arbitrage window narrowed; bots throttled to conservative posture.</span></li>
+                </ul>
+            </article>
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-robot"></i></span>
+                        <div>
+                            <h3>LLM Commentary</h3>
+                            <p class="text-muted">Mono captions reinforce that insights came from machine copilots.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Analysis</span>
+                </div>
+                <div class="testimonial">
+                    <p><strong>"Maintaining the scalping palette in our reports keeps operators anchored in mission-critical telemetry."
+                    </strong></p>
+                    <p class="text-muted">— Synthetic Analyst · Neon Ops Bot #19</p>
+                    <p>The stylesheet handles italics, callouts, and inline metrics so narrative sections still feel like part of the console, not a detached PDF.</p>
+                </div>
+            </article>
+        </section>
+
+        <section class="section">
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-signal"></i></span>
+                        <div>
+                            <h3>Performance Benchmarks</h3>
+                            <p class="text-muted">Highlight comparative stats with consistent glow cues.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">KPIs</span>
+                </div>
+                <div class="table-wrapper">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Segment</th>
+                                <th>MoM P&amp;L</th>
+                                <th>Sharpe</th>
+                                <th>LLM Confidence</th>
+                                <th>Status</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>HFT Equities</td>
+                                <td>+4.8%</td>
+                                <td>1.9</td>
+                                <td>96%</td>
+                                <td><span class="status-chip success"><i class="fas fa-circle"></i> outperform</span></td>
+                            </tr>
+                            <tr>
+                                <td>Energy Futures</td>
+                                <td>+1.2%</td>
+                                <td>1.3</td>
+                                <td>88%</td>
+                                <td><span class="status-chip warning"><i class="fas fa-circle"></i> watch</span></td>
+                            </tr>
+                            <tr>
+                                <td>Digital Assets</td>
+                                <td>-0.6%</td>
+                                <td>0.9</td>
+                                <td>74%</td>
+                                <td><span class="status-chip danger"><i class="fas fa-circle"></i> action</span></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </article>
+        </section>
+    </main>
+</body>
+</html>

--- a/docs/style-guide/samples/team.html
+++ b/docs/style-guide/samples/team.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Trading AI Consulting · Team Sample</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-GL3FZmWfP7HQP9PL8uEjzsv+VKYQHzNmgP8lR+W3qIx2P2+41sJLdnOjFkWDXLI4YAlnXrhIRbkIuAeGHGZ1sA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="../scalping-global.css">
+</head>
+<body>
+    <main class="page">
+        <nav class="nav-bar">
+            <span class="nav-brand">
+                <span class="mark"><i class="fas fa-users"></i></span>
+                Neon Strike Collective
+            </span>
+            <div class="nav-links">
+                <a href="#">Who We Are</a>
+                <a href="#">Traders</a>
+                <a href="#">Data</a>
+                <a href="#">Advisors</a>
+            </div>
+        </nav>
+
+        <section class="section">
+            <div class="section-header">
+                <span class="section-kicker"><i class="fas fa-user-astronaut"></i> Operators</span>
+                <h2>Talent screens share the same neon depth as the scalping floor.</h2>
+                <p class="text-muted">Present your team with the glow, blur, and monochrome overlays users already trust inside the production console. Avatar halos, panel badges, and cyan captions all come along for the ride.</p>
+            </div>
+
+            <div class="grid-3">
+                <article class="panel">
+                    <div class="panel-header">
+                        <div class="panel-title">
+                            <span class="icon"><i class="fas fa-user-ninja"></i></span>
+                            <div>
+                                <h3>Execution Pods</h3>
+                                <p class="text-muted">Quant traders with scalping obsession.</p>
+                            </div>
+                        </div>
+                        <span class="panel-tag">Tokyo</span>
+                    </div>
+                    <div class="avatar-row">
+                        <span class="avatar">AK</span>
+                        <span class="avatar">JM</span>
+                        <span class="avatar">SY</span>
+                    </div>
+                    <p class="text-muted">Profiles emphasize venue mastery, risk posture, and automation coverage without losing the neon DNA.</p>
+                </article>
+                <article class="panel">
+                    <div class="panel-header">
+                        <div class="panel-title">
+                            <span class="icon"><i class="fas fa-database"></i></span>
+                            <div>
+                                <h3>Data Spine</h3>
+                                <p class="text-muted">Engineers running the ingestion lattice.</p>
+                            </div>
+                        </div>
+                        <span class="panel-tag">New York</span>
+                    </div>
+                    <div class="avatar-row">
+                        <span class="avatar">LN</span>
+                        <span class="avatar">CF</span>
+                        <span class="avatar">HB</span>
+                    </div>
+                    <p class="text-muted">Use tag groups for specialties: <span class="tag">Alt Data</span> <span class="tag">Latency</span> <span class="tag">LLM Guard</span>.</p>
+                </article>
+                <article class="panel">
+                    <div class="panel-header">
+                        <div class="panel-title">
+                            <span class="icon"><i class="fas fa-shield-heart"></i></span>
+                            <div>
+                                <h3>Risk &amp; Trust</h3>
+                                <p class="text-muted">Governance leaders with AI expertise.</p>
+                            </div>
+                        </div>
+                        <span class="panel-tag">London</span>
+                    </div>
+                    <div class="avatar-row">
+                        <span class="avatar">EC</span>
+                        <span class="avatar">RS</span>
+                        <span class="avatar">TD</span>
+                    </div>
+                    <p class="text-muted">Timeline modules capture their oversight, while testimonials keep copy crisp.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section grid-2">
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-wave-square"></i></span>
+                        <div>
+                            <h3>Partner Network</h3>
+                            <p class="text-muted">Bring in strategic collaborators without breaking the vibe.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Allies</span>
+                </div>
+                <ul class="bullet-list">
+                    <li><span class="dot"></span><span><strong>LLM Safety Consortium</strong> · Shares compliance updates through neon-coded pulses.</span></li>
+                    <li><span class="dot"></span><span><strong>Exchange Integrators</strong> · Provide zero-downtime gateway upgrades.</span></li>
+                    <li><span class="dot"></span><span><strong>Ops Bureaus</strong> · Staff follow-the-sun response teams.</span></li>
+                </ul>
+            </article>
+            <article class="panel">
+                <div class="panel-header">
+                    <div class="panel-title">
+                        <span class="icon"><i class="fas fa-comment-dots"></i></span>
+                        <div>
+                            <h3>Culture Notes</h3>
+                            <p class="text-muted">Lean on testimonials for tone that still feels like telemetry.</p>
+                        </div>
+                    </div>
+                    <span class="panel-tag">Voice</span>
+                </div>
+                <div class="testimonial">
+                    <p><strong>"Our brightest ideas land when they look like they belong in the scalping cockpit."</strong></p>
+                    <p class="text-muted">— Head of Ops Enablement</p>
+                    <p>Glass cards soak up quotes, stats, and blurbs so the team page reads like part of the mission console.</p>
+                </div>
+            </article>
+        </section>
+    </main>
+</body>
+</html>

--- a/docs/style-guide/scalping-global.css
+++ b/docs/style-guide/scalping-global.css
@@ -1,0 +1,714 @@
+:root {
+    --bg-base: #040405;
+    --bg-elevated: rgba(14, 18, 24, 0.82);
+    --bg-elevated-strong: rgba(18, 24, 33, 0.94);
+    --bg-panel: linear-gradient(135deg, rgba(22, 29, 39, 0.95), rgba(12, 17, 24, 0.78));
+    --bg-panel-soft: linear-gradient(160deg, rgba(18, 26, 34, 0.92), rgba(9, 12, 18, 0.88));
+    --grid-line: rgba(44, 255, 224, 0.06);
+    --grid-highlight: rgba(44, 255, 224, 0.12);
+    --text-high: rgba(249, 252, 255, 0.96);
+    --text-med: rgba(203, 214, 228, 0.78);
+    --text-low: rgba(203, 214, 228, 0.52);
+    --accent-cyan: #3df6ff;
+    --accent-green: #38f59d;
+    --accent-purple: #8c7bff;
+    --accent-amber: #ffb86c;
+    --accent-red: #ff6577;
+    --outline-glow: rgba(61, 246, 255, 0.55);
+    --outline-glow-soft: rgba(61, 246, 255, 0.15);
+    --shadow-xl: 0 24px 50px rgba(4, 228, 191, 0.18);
+    --shadow-lg: 0 18px 36px rgba(4, 228, 191, 0.15);
+    --shadow-md: 0 12px 24px rgba(4, 228, 191, 0.1);
+    --radius-lg: 24px;
+    --radius-md: 18px;
+    --radius-sm: 12px;
+    --font-sans: "Inter", "Space Grotesk", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-mono: "JetBrains Mono", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    --transition: 220ms ease;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: var(--font-sans);
+    background-color: var(--bg-base);
+    color: var(--text-med);
+    margin: 0;
+    min-height: 100vh;
+    line-height: 1.7;
+    letter-spacing: 0.01em;
+    position: relative;
+    overflow-x: hidden;
+}
+
+body::before,
+body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    pointer-events: none;
+    z-index: -2;
+}
+
+body::before {
+    background:
+        radial-gradient(1200px at 20% 10%, rgba(61, 246, 255, 0.18), transparent 70%),
+        radial-gradient(900px at 80% 0%, rgba(140, 123, 255, 0.2), transparent 65%),
+        linear-gradient(120deg, rgba(2, 10, 18, 0.94), rgba(6, 10, 14, 0.92));
+}
+
+body::after {
+    background-image:
+        linear-gradient(90deg, var(--grid-line) 1px, transparent 1px),
+        linear-gradient(0deg, var(--grid-line) 1px, transparent 1px);
+    background-size: 140px 140px;
+    opacity: 0.45;
+    mask: radial-gradient(circle at 50% 20%, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.05) 65%, transparent 100%);
+}
+
+a {
+    color: var(--accent-cyan);
+    text-decoration: none;
+    transition: color var(--transition);
+}
+
+a:hover {
+    color: var(--accent-green);
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.page {
+    width: min(1180px, 92vw);
+    margin: 0 auto;
+    padding: 96px 0 120px;
+}
+
+.section {
+    margin-top: 72px;
+}
+
+.section:first-child {
+    margin-top: 0;
+}
+
+.section-header {
+    margin-bottom: 32px;
+}
+
+.section-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.28em;
+    font-size: 0.68rem;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(61, 246, 255, 0.32);
+    background: rgba(61, 246, 255, 0.08);
+    color: rgba(191, 244, 255, 0.8);
+    margin-bottom: 18px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5 {
+    color: var(--text-high);
+    font-weight: 600;
+    margin: 0 0 16px;
+}
+
+h1 {
+    font-size: clamp(2.75rem, 5vw, 3.75rem);
+    letter-spacing: -0.015em;
+}
+
+h2 {
+    font-size: clamp(2rem, 3.8vw, 2.6rem);
+}
+
+h3 {
+    font-size: clamp(1.35rem, 2.5vw, 1.6rem);
+}
+
+p {
+    margin: 0 0 20px;
+}
+
+.text-muted {
+    color: var(--text-low);
+}
+
+strong,
+.bold {
+    color: var(--text-high);
+}
+
+.lead {
+    font-size: 1.15rem;
+    color: rgba(241, 248, 255, 0.78);
+    max-width: 58ch;
+}
+
+.nav-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 28px;
+    border-radius: var(--radius-md);
+    background: rgba(10, 14, 20, 0.8);
+    border: 1px solid rgba(61, 246, 255, 0.15);
+    box-shadow: var(--shadow-md);
+    backdrop-filter: blur(14px);
+    margin-bottom: 54px;
+}
+
+.nav-brand {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-weight: 600;
+    font-size: 1.05rem;
+    color: var(--text-high);
+}
+
+.nav-brand .mark {
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, rgba(61, 246, 255, 0.2), rgba(140, 123, 255, 0.5));
+    display: grid;
+    place-items: center;
+    color: var(--accent-cyan);
+    box-shadow: inset 0 0 0 1px rgba(61, 246, 255, 0.35);
+}
+
+.nav-links {
+    display: flex;
+    gap: 24px;
+    font-size: 0.95rem;
+}
+
+.nav-links a {
+    color: var(--text-med);
+    position: relative;
+}
+
+.nav-links a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -8px;
+    width: 100%;
+    height: 2px;
+    background: linear-gradient(90deg, transparent, var(--accent-cyan), transparent);
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform var(--transition);
+}
+
+.nav-links a:hover::after {
+    transform: scaleX(1);
+}
+
+.hero {
+    display: grid;
+    gap: 48px;
+    align-items: center;
+    background: var(--bg-panel);
+    border: 1px solid rgba(61, 246, 255, 0.18);
+    border-radius: var(--radius-lg);
+    padding: clamp(32px, 5vw, 54px);
+    box-shadow: var(--shadow-xl);
+    position: relative;
+    overflow: hidden;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    background: linear-gradient(120deg, rgba(61, 246, 255, 0.2), transparent 55%, rgba(140, 123, 255, 0.16));
+    opacity: 0;
+    transition: opacity var(--transition);
+}
+
+.hero:hover::after {
+    opacity: 1;
+}
+
+.hero-copy p {
+    color: rgba(225, 242, 255, 0.72);
+}
+
+.hero-aside {
+    display: grid;
+    gap: 16px;
+}
+
+.hero-aside .glow-box {
+    padding: 18px 20px;
+    border-radius: var(--radius-md);
+    background: rgba(8, 14, 21, 0.82);
+    border: 1px solid rgba(61, 246, 255, 0.16);
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    backdrop-filter: blur(14px);
+}
+
+.hero-aside .glow-box strong {
+    font-size: 1.4rem;
+}
+
+.button-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 32px;
+}
+
+.btn-primary,
+.btn-ghost {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 26px;
+    font-weight: 600;
+    border-radius: 999px;
+    font-size: 0.98rem;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+}
+
+.btn-primary {
+    background: linear-gradient(120deg, rgba(61, 246, 255, 0.92), rgba(56, 245, 157, 0.9));
+    color: #021d16;
+    box-shadow: var(--shadow-lg);
+    border: none;
+}
+
+.btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 48px rgba(61, 246, 255, 0.25);
+}
+
+.btn-ghost {
+    border: 1px solid rgba(61, 246, 255, 0.3);
+    background: rgba(9, 17, 24, 0.75);
+    color: rgba(214, 240, 255, 0.82);
+}
+
+.btn-ghost:hover {
+    background: rgba(9, 17, 24, 0.95);
+    color: var(--accent-cyan);
+    transform: translateY(-2px);
+}
+
+.metric-grid {
+    display: grid;
+    gap: 18px;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    margin-top: 36px;
+}
+
+.metric {
+    padding: 20px 22px;
+    border-radius: var(--radius-md);
+    background: rgba(9, 14, 21, 0.76);
+    border: 1px solid rgba(61, 246, 255, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(61, 246, 255, 0.06);
+}
+
+.metric span {
+    display: block;
+    font-size: 0.78rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-low);
+    margin-bottom: 14px;
+}
+
+.metric strong {
+    font-size: 1.8rem;
+}
+
+.grid-2 {
+    display: grid;
+    gap: 24px;
+}
+
+.grid-3 {
+    display: grid;
+    gap: 24px;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.panel {
+    background: var(--bg-panel-soft);
+    border-radius: var(--radius-lg);
+    border: 1px solid rgba(61, 246, 255, 0.18);
+    padding: 28px;
+    position: relative;
+    overflow: hidden;
+}
+
+.panel::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(61, 246, 255, 0.18), transparent 50%, rgba(140, 123, 255, 0.15));
+    opacity: 0;
+    transition: opacity var(--transition);
+    pointer-events: none;
+}
+
+.panel:hover::after {
+    opacity: 1;
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 20px;
+}
+
+.panel-title {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    font-size: 1.1rem;
+}
+
+.panel-title .icon {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    display: grid;
+    place-items: center;
+    background: rgba(61, 246, 255, 0.1);
+    border: 1px solid rgba(61, 246, 255, 0.35);
+    color: var(--accent-cyan);
+}
+
+.panel-tag {
+    padding: 6px 14px;
+    border-radius: 999px;
+    background: rgba(61, 246, 255, 0.12);
+    border: 1px solid rgba(61, 246, 255, 0.24);
+    color: rgba(214, 240, 255, 0.72);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+}
+
+.bullet-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 12px;
+}
+
+.bullet-list li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 12px;
+    align-items: start;
+}
+
+.bullet-list .dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--accent-cyan);
+    margin-top: 8px;
+}
+
+.tag-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.tag {
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    border: 1px solid rgba(61, 246, 255, 0.16);
+    color: rgba(214, 240, 255, 0.7);
+    background: rgba(9, 17, 24, 0.8);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(61, 246, 255, 0.16);
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 520px;
+    background: rgba(10, 16, 23, 0.86);
+}
+
+thead tr {
+    background: rgba(61, 246, 255, 0.08);
+}
+
+thead th {
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: rgba(214, 240, 255, 0.68);
+    padding: 16px;
+    text-align: left;
+    border-bottom: 1px solid rgba(61, 246, 255, 0.2);
+}
+
+tbody td {
+    padding: 16px;
+    border-bottom: 1px solid rgba(61, 246, 255, 0.08);
+}
+
+tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.status-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.status-chip.success {
+    background: rgba(56, 245, 157, 0.14);
+    border: 1px solid rgba(56, 245, 157, 0.28);
+    color: rgba(188, 255, 222, 0.95);
+}
+
+.status-chip.warning {
+    background: rgba(255, 184, 108, 0.16);
+    border: 1px solid rgba(255, 184, 108, 0.3);
+    color: rgba(255, 231, 207, 0.92);
+}
+
+.status-chip.danger {
+    background: rgba(255, 101, 119, 0.16);
+    border: 1px solid rgba(255, 101, 119, 0.32);
+    color: rgba(255, 215, 222, 0.9);
+}
+
+.timeline {
+    display: grid;
+    gap: 18px;
+    position: relative;
+    padding-left: 18px;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    left: 6px;
+    top: 6px;
+    bottom: 6px;
+    width: 2px;
+    background: linear-gradient(180deg, rgba(61, 246, 255, 0.32), transparent);
+}
+
+.timeline-item {
+    position: relative;
+    padding-left: 26px;
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -6px;
+    top: 4px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--accent-cyan);
+    box-shadow: 0 0 0 4px rgba(61, 246, 255, 0.15);
+}
+
+.timeline-item time {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.14em;
+    color: var(--text-low);
+}
+
+.avatar-row {
+    display: flex;
+    gap: 14px;
+}
+
+.avatar {
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    background: rgba(61, 246, 255, 0.15);
+    border: 1px solid rgba(61, 246, 255, 0.45);
+    display: grid;
+    place-items: center;
+    font-weight: 600;
+    color: var(--accent-cyan);
+}
+
+.testimonial {
+    display: grid;
+    gap: 18px;
+    background: rgba(8, 12, 18, 0.82);
+    border: 1px solid rgba(61, 246, 255, 0.16);
+    border-radius: var(--radius-md);
+    padding: 24px;
+}
+
+.contact-card {
+    display: grid;
+    gap: 24px;
+    background: rgba(9, 14, 21, 0.85);
+    border: 1px solid rgba(61, 246, 255, 0.2);
+    border-radius: var(--radius-lg);
+    padding: 32px;
+}
+
+.contact-actions {
+    display: grid;
+    gap: 18px;
+}
+
+.info-line {
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    padding: 14px 18px;
+    background: rgba(9, 16, 24, 0.72);
+    border-radius: var(--radius-md);
+    border: 1px solid rgba(61, 246, 255, 0.12);
+}
+
+.info-line i {
+    font-size: 1.1rem;
+    color: var(--accent-cyan);
+}
+
+.form-grid {
+    display: grid;
+    gap: 18px;
+}
+
+label {
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: rgba(194, 236, 255, 0.7);
+}
+
+input,
+textarea,
+select {
+    width: 100%;
+    padding: 14px 16px;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(61, 246, 255, 0.18);
+    background: rgba(7, 12, 18, 0.84);
+    color: var(--text-high);
+    font-family: inherit;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+    outline: 2px solid rgba(61, 246, 255, 0.35);
+}
+
+textarea {
+    min-height: 150px;
+    resize: vertical;
+}
+
+.footer {
+    margin-top: 72px;
+    padding: 36px;
+    border-radius: var(--radius-lg);
+    background: rgba(9, 15, 22, 0.85);
+    border: 1px solid rgba(61, 246, 255, 0.2);
+    display: grid;
+    gap: 24px;
+    text-align: center;
+}
+
+.footer p {
+    margin: 0;
+}
+
+.utility-grid {
+    display: grid;
+    gap: 18px;
+}
+
+.utility-grid .stat {
+    display: grid;
+    gap: 10px;
+    padding: 18px 20px;
+    border-radius: var(--radius-md);
+    background: rgba(9, 14, 21, 0.78);
+    border: 1px solid rgba(61, 246, 255, 0.15);
+}
+
+.utility-grid .stat strong {
+    font-size: 1.6rem;
+}
+
+@media (min-width: 720px) {
+    .hero {
+        grid-template-columns: 1.1fr 0.9fr;
+    }
+
+    .grid-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .utility-grid {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .contact-actions {
+        grid-template-columns: 1.1fr 0.9fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .nav-bar {
+        flex-direction: column;
+        gap: 18px;
+        align-items: flex-start;
+    }
+
+    .nav-links {
+        flex-wrap: wrap;
+    }
+}


### PR DESCRIPTION
## Summary
- redesign `scalping-global.css` around a dark neon grid backdrop, frosted glass panels, and gradient CTAs that match the shared scalping reference
- update the style guide documentation to explain the new asset requirements, tokens, and component classes shipped in the refreshed stylesheet
- rebuild the landing, dashboard, market report, team, and contact samples to demonstrate the unified look without any Bootstrap dependencies

## Testing
- not run (static HTML/CSS assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d6d0e3fd50832a80ff47219e7681fd