### PR TITLE
Integrate Go-based historical optimizer for sentiment analysis

### DIFF
--- a/docs/sentiment_analysis_overview.md
+++ b/docs/sentiment_analysis_overview.md
@@ -1,0 +1,29 @@
+# Sentiment Analysis Overview
+
+## News collection and filtering
+- The `DataFetcher` aggregates company news from multiple upstream sources (Alpha Vantage, Reddit, Finnhub, and Yahoo Finance), deduplicates by headline, and filters aggressively for symbol-specific coverage so that the downstream model receives focused inputs. This routine also injects deterministic fallback blurbs when few articles survive filtering to keep the analysis pipeline alive.
+- News items are sorted by recency and the source mix is logged for transparency before the sentiment step runs.
+
+## Prompt preparation and scoring
+- `SentimentAnalyzer.analyze_news_sentiment` merges stock-specific and general articles, applying higher weights to ticker-focused pieces so their tone dominates the final score.
+- Each article now contributes a compact bullet that contains the headline, an automatically shortened summary, its weighting factor, and (when available) the originating source. This keeps the language model prompt short while still conveying the main idea of every article that made it through filtering while giving the LLM visibility into repeatedly accurate outlets.
+- The analyzer builds a context-specific prompt (crypto vs. equities), dispatches it to the configured provider (Ollama, DeepSeek, or OpenAI), and performs defensive parsing of the JSON payload before returning a normalized `sentiment_score`, `confidence`, and summary string.
+
+## Historical optimization without RAG
+- Before the prompt is built, the combined news set plus optional historical sentiment records are forwarded to a lightweight Go helper (`go/cmd/sentiment_optimizer`). The helper re-weights each article using:
+  - historical alignment between prior sentiment calls and realized returns per news source;
+  - recency decay to keep stale articles from dominating the prompt; and
+  - aggregate drift indicators that surface whether the underlying sentiment tends to over- or under-shoot actual price moves.
+- The Go process returns calibrated weights along with a baseline sentiment shift and confidence nudge. The Python analyzer applies these adjustments post-LLM to keep the final score grounded in observed outcomes while avoiding a full retrieval-augmented generation (RAG) setup.
+- Historical records can be supplied programmatically (via the `historical_sentiment` argument) or by pointing `Config.HISTORICAL_SENTIMENT_PATH` at a JSON file shaped as `{ "TICKER": [{"sentiment": 0.2, "realized_return": 0.15, ...}] }`. Missing or unreadable data gracefully fall back to the default recency heuristics with clear log messages.
+- Optimizer diagnostics (per-source accuracy, baseline drift, and notes on the applied adjustments) are returned in `analysis_metadata['go_optimizer']` so the UI or downstream analytics can highlight why the score moved.
+
+## Fallback behaviour
+- When AI providers are unreachable or return invalid payloads, the analyzer drops to a neutral sentiment response. If news is entirely unavailable, price-based heuristics (`analyze_price_based_sentiment`) generate a backup sentiment score from price momentum and technical cues.
+
+## Easy wins to improve recommendations
+- Tighten the summarization step further by trimming redundant boilerplate ("press release", "reuters", etc.) to buy more prompt space for substantive facts.
+- Expand metadata returned to the UI (for example, include per-article confidence heuristics such as source credibility) so the frontend can visualize why the score looks the way it does. The Go optimizer now exposes these credibility signals by source, but the frontend can bubble them up more prominently.
+- Cache per-article sentiment snippets to avoid re-querying the LLM when the same article appears across multiple tickers, reducing latency and cost while improving consistency.
+- Blend the current news-driven score with the historical backtest confidence that already powers strategy ranking to highlight ideas that align both with sentiment and with proven performance.
+- Track the predictive quality of generated sentiment versus realized returns inside a lightweight store so the Go helper's baseline and confidence tweaks can become more personalized over time (e.g., per-sector or per-volatility regime).

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module tradingai
+
+go 1.21

--- a/go/cmd/sentiment_optimizer/main.go
+++ b/go/cmd/sentiment_optimizer/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"tradingai/go/pkg/optimizer"
+)
+
+func main() {
+	decoder := json.NewDecoder(os.Stdin)
+	var input optimizer.Input
+	if err := decoder.Decode(&input); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to decode input: %v\n", err)
+		os.Exit(1)
+	}
+
+	output := optimizer.Optimize(input)
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(output); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to encode output: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/go/pkg/optimizer/optimizer.go
+++ b/go/pkg/optimizer/optimizer.go
@@ -1,0 +1,269 @@
+package optimizer
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type Article struct {
+	Weight      float64 `json:"weight"`
+	Headline    string  `json:"headline"`
+	Summary     string  `json:"summary"`
+	Source      string  `json:"source"`
+	PublishedAt string  `json:"published_at"`
+}
+
+type HistoryPoint struct {
+	Sentiment      float64 `json:"sentiment"`
+	RealizedReturn float64 `json:"realized_return"`
+	Confidence     float64 `json:"confidence"`
+	Volume         float64 `json:"volume"`
+	Source         string  `json:"source"`
+	Timestamp      string  `json:"timestamp"`
+}
+
+type Input struct {
+	Articles []Article      `json:"articles"`
+	History  []HistoryPoint `json:"history"`
+}
+
+type Output struct {
+	Weights              []float64          `json:"weights"`
+	BaselineShift        float64            `json:"baseline_shift"`
+	ConfidenceAdjustment float64            `json:"confidence_adjustment"`
+	Diagnostics          map[string]float64 `json:"diagnostics"`
+	Notes                []string           `json:"notes"`
+}
+
+type sourceAggregate struct {
+	Accuracy float64
+	Weight   float64
+	Count    int
+	Original string
+}
+
+// Optimize returns re-weighted news articles and historical adjustments that are later
+// consumed by the Python sentiment analyzer.
+func Optimize(input Input) Output {
+	output := Output{
+		Weights:     make([]float64, len(input.Articles)),
+		Diagnostics: map[string]float64{},
+	}
+
+	now := time.Now().UTC()
+
+	if len(input.Articles) == 0 {
+		output.Notes = append(output.Notes, "No articles supplied to optimizer.")
+		return output
+	}
+
+	stats := map[string]*sourceAggregate{}
+	totalAccuracy := 0.0
+	totalWeight := 0.0
+	accuracySquares := 0.0
+
+	for _, row := range input.History {
+		weight := clamp(row.Confidence, 0.05, 1.0)
+		if row.Volume > 0 {
+			weight += clamp(row.Volume/1e7, 0, 0.35)
+		}
+		timestamp := parseTime(row.Timestamp)
+		if !timestamp.IsZero() {
+			ageHours := now.Sub(timestamp).Hours()
+			if ageHours < 0 {
+				ageHours = 0
+			}
+			switch {
+			case ageHours <= 24:
+				weight *= 1.25
+			case ageHours <= 168:
+				weight *= 1.0
+			default:
+				weight *= 0.65
+			}
+		}
+
+		accuracy := row.Sentiment * row.RealizedReturn
+		totalAccuracy += accuracy * weight
+		totalWeight += weight
+		accuracySquares += accuracy * accuracy * weight
+
+		key := normalizeSource(row.Source)
+		agg := stats[key]
+		if agg == nil {
+			agg = &sourceAggregate{}
+			stats[key] = agg
+		}
+		if agg.Original == "" && strings.TrimSpace(row.Source) != "" {
+			agg.Original = row.Source
+		}
+		agg.Accuracy += accuracy * weight
+		agg.Weight += weight
+		agg.Count++
+	}
+
+	notes := []string{}
+	if totalWeight > 0 {
+		mean := totalAccuracy / totalWeight
+		output.BaselineShift = clamp(mean, -0.3, 0.3)
+		output.Diagnostics["historical_weight"] = totalWeight
+		output.Diagnostics["historical_alignment"] = mean
+		variance := 0.0
+		if totalWeight > 0 {
+			variance = (accuracySquares / totalWeight) - (mean * mean)
+			if variance < 0 {
+				variance = 0
+			}
+		}
+		output.Diagnostics["historical_variance"] = variance
+		switch {
+		case variance < 0.01:
+			output.ConfidenceAdjustment = 0.08
+		case variance < 0.04:
+			output.ConfidenceAdjustment = 0.04
+		case variance > 0.2:
+			output.ConfidenceAdjustment = -0.05
+		}
+		if output.BaselineShift > 0.05 {
+			notes = append(notes, fmt.Sprintf("Sentiment skew trending bullish (+%.2f)", output.BaselineShift))
+		} else if output.BaselineShift < -0.05 {
+			notes = append(notes, fmt.Sprintf("Sentiment skew trending bearish (%.2f)", output.BaselineShift))
+		}
+	} else if len(input.History) == 0 {
+		notes = append(notes, "No historical sentiment records provided; falling back to recency heuristics.")
+	}
+
+	bestSource, bestScore := "", -math.MaxFloat64
+	worstSource, worstScore := "", math.MaxFloat64
+	for key, agg := range stats {
+		score := 0.0
+		if agg.Weight > 0 {
+			score = agg.Accuracy / agg.Weight
+		}
+		output.Diagnostics["source:"+key] = score
+		if score > bestScore {
+			bestSource, bestScore = key, score
+		}
+		if score < worstScore {
+			worstSource, worstScore = key, score
+		}
+	}
+
+	if bestSource != "" && bestScore > 0 {
+		notes = append(notes, fmt.Sprintf("%s historically aligned with price action (+%.2f)", prettifySource(stats[bestSource].Original, bestSource), bestScore))
+	}
+	if worstSource != "" && worstScore < 0 {
+		notes = append(notes, fmt.Sprintf("%s skewed negative historically (%.2f)", prettifySource(stats[worstSource].Original, worstSource), worstScore))
+	}
+
+	output.Notes = notes
+
+	for idx, article := range input.Articles {
+		baseWeight := article.Weight
+		if baseWeight <= 0 {
+			baseWeight = 1.0
+		}
+		sourceFactor := 1.0
+		sourceKey := normalizeSource(article.Source)
+		if agg, ok := stats[sourceKey]; ok && agg.Weight > 0 {
+			score := agg.Accuracy / agg.Weight
+			sourceFactor = clamp(1.0+score*0.6, 0.4, 1.6)
+		}
+
+		recencyFactor := 1.0
+		ts := parseTime(article.PublishedAt)
+		if !ts.IsZero() {
+			ageHours := now.Sub(ts).Hours()
+			if ageHours < 0 {
+				ageHours = 0
+			}
+			switch {
+			case ageHours <= 12:
+				recencyFactor = 1.18
+			case ageHours <= 48:
+				recencyFactor = 1.08
+			case ageHours >= 120:
+				recencyFactor = 0.82
+			}
+		}
+
+		adjusted := baseWeight * sourceFactor * recencyFactor
+		if adjusted < 0.2 {
+			adjusted = 0.2
+		}
+		output.Weights[idx] = adjusted
+	}
+
+	return output
+}
+
+func clamp(value, minValue, maxValue float64) float64 {
+	if value < minValue {
+		return minValue
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}
+
+func normalizeSource(source string) string {
+	trimmed := strings.TrimSpace(strings.ToLower(source))
+	if trimmed == "" {
+		return "unknown"
+	}
+	return trimmed
+}
+
+func prettifySource(original, fallback string) string {
+	candidate := strings.TrimSpace(original)
+	if candidate == "" {
+		candidate = fallback
+	}
+	if candidate == "" {
+		return "Unknown source"
+	}
+	parts := strings.FieldsFunc(candidate, func(r rune) bool {
+		return r == '_' || r == '-' || r == '.'
+	})
+	for i, part := range parts {
+		part = strings.ToLower(part)
+		if len(part) == 0 {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+func parseTime(value string) time.Time {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}
+	}
+	// Try RFC3339 / ISO8601 first.
+	if ts, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return ts.UTC()
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if ts, err := time.Parse(layout, trimmed); err == nil {
+			return ts.UTC()
+		}
+	}
+	if numeric, err := strconv.ParseFloat(trimmed, 64); err == nil {
+		if numeric > 1e12 {
+			numeric = numeric / 1000
+		}
+		if numeric > 0 {
+			return time.Unix(int64(numeric), 0).UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/src/core/sentiment_analyzer.py
+++ b/src/core/sentiment_analyzer.py
@@ -1,10 +1,16 @@
+import json
+import subprocess
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
 import openai
 import requests
-from typing import List, Dict
-import json
-from .config import Config
 import numpy as np
 import re  # Added for regex fallback
+
+from .config import Config
 
 # Import API tracker for monitoring API usage
 # from src.utils.api_tracker import api_tracker  # Module removed
@@ -20,6 +26,11 @@ class SentimentAnalyzer:
         except AttributeError:
             self.openai_client = None
             self.use_new_openai_api = False
+        self._repo_root = Path(__file__).resolve().parents[2]
+        self.historical_sentiment_path = getattr(
+            Config, "HISTORICAL_SENTIMENT_PATH", None
+        )
+        self._go_missing_logged = False
         # DeepSeek setup
         self.deepseek_api_key = getattr(Config, "DEEPSEEK_API_KEY", None)
         self.deepseek_base_url = "https://api.deepseek.com/v1"
@@ -145,6 +156,215 @@ class SentimentAnalyzer:
                 temperature=0.1,
             )
         return response
+
+    def _summarize_text(
+        self, text: str, max_sentences: int = 2, max_chars: int = 220
+    ) -> str:
+        """Return a short, human-readable summary for article bodies."""
+
+        if not text:
+            return "No summary provided."
+
+        # Collapse repeated whitespace to avoid wasting tokens.
+        cleaned = " ".join(str(text).split())
+        if not cleaned:
+            return "No summary provided."
+
+        # Capture the leading sentences so the LLM sees the main takeaway first.
+        sentences = re.split(r"(?<=[.!?])\s+", cleaned)
+        summary = " ".join(sentences[:max_sentences]).strip()
+        if not summary:
+            summary = cleaned
+
+        if len(summary) > max_chars:
+            truncated = summary[:max_chars].rstrip(",;:- ")
+            if " " in truncated:
+                truncated = truncated.rsplit(" ", 1)[0]
+            summary = f"{truncated}…"
+
+        return summary
+
+    def _build_weighted_prompt(
+        self, combined_news: List[Dict]
+    ) -> Tuple[str, float, int]:
+        """Format weighted news entries into a concise prompt."""
+
+        prompt_lines: List[str] = []
+        total_weight = 0.0
+
+        for idx, article in enumerate(combined_news, start=1):
+            weight = float(article.get("weight", 1.0))
+            headline = (article.get("headline") or "Untitled article").strip()
+            raw_summary = (
+                article.get("summary")
+                or article.get("description")
+                or article.get("selftext")
+                or ""
+            )
+            summary = self._summarize_text(raw_summary)
+            source = article.get("source")
+            source_tag = f" ({source})" if source else ""
+
+            prompt_lines.append(
+                f"{idx}. Weight {weight:.1f}{source_tag} — {headline}\n   Summary: {summary}"
+            )
+            total_weight += weight
+
+        news_text = "\n".join(prompt_lines)
+        return news_text, total_weight, len(prompt_lines)
+
+    def _normalize_timestamp(self, value) -> Optional[str]:
+        """Return an ISO-8601 timestamp string when possible."""
+
+        if value in (None, ""):
+            return None
+
+        try:
+            if isinstance(value, (int, float)):
+                # Accept timestamps provided in seconds or milliseconds.
+                normalized = float(value)
+                if normalized > 1e12:
+                    normalized /= 1000.0
+                dt_value = datetime.fromtimestamp(normalized, tz=timezone.utc)
+                return dt_value.isoformat()
+            if isinstance(value, str):
+                text = value.strip()
+                if not text:
+                    return None
+                # Accept already-normalized timestamps.
+                try:
+                    dt_value = datetime.fromisoformat(text.replace("Z", "+00:00"))
+                except ValueError:
+                    return text
+                return dt_value.isoformat()
+        except Exception:
+            return None
+        return None
+
+    def _safe_float(self, value, default: float = 0.0) -> float:
+        """Coerce values to float without raising."""
+
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    def _load_historical_sentiment(self, symbol: Optional[str]) -> List[Dict]:
+        """Load historical sentiment rows for the given symbol if configured."""
+
+        if not symbol or not self.historical_sentiment_path:
+            return []
+
+        try:
+            path = Path(self.historical_sentiment_path)
+        except TypeError:
+            return []
+
+        if not path.exists():
+            return []
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - defensive logging only
+            print(f"⚠️ Unable to read historical sentiment data: {exc}")
+            return []
+
+        if not isinstance(payload, dict):
+            return []
+
+        symbol_key_variants = {
+            symbol,
+            symbol.upper(),
+            symbol.lower(),
+        }
+        entries: List[Dict] = []
+        for key in symbol_key_variants:
+            if key in payload and isinstance(payload[key], list):
+                entries = payload[key]
+                break
+
+        normalized_entries: List[Dict] = []
+        for row in entries:
+            if not isinstance(row, dict):
+                continue
+            normalized_entries.append(
+                {
+                    "sentiment": self._safe_float(
+                        row.get("sentiment", row.get("sentiment_score")), 0.0
+                    ),
+                    "realized_return": self._safe_float(
+                        row.get("realized_return", row.get("return")), 0.0
+                    ),
+                    "confidence": self._safe_float(row.get("confidence"), 0.5),
+                    "volume": self._safe_float(row.get("volume"), 0.0),
+                    "source": row.get("source", ""),
+                    "timestamp": self._normalize_timestamp(
+                        row.get("timestamp")
+                        or row.get("date")
+                        or row.get("datetime")
+                    ),
+                }
+            )
+
+        return normalized_entries
+
+    def _optimize_with_go(
+        self, articles: List[Dict], historical_rows: Optional[List[Dict]] = None
+    ) -> Optional[Dict]:
+        """Invoke the Go helper to refine weights using historical outcomes."""
+
+        go_binary = shutil.which("go")
+        if not go_binary:
+            if not self._go_missing_logged:
+                print(
+                    "⚠️ Go runtime is not available on the system. Skipping optimizer step."
+                )
+                self._go_missing_logged = True
+            return None
+
+        payload = {
+            "articles": articles,
+            "history": historical_rows or [],
+        }
+
+        try:
+            completed = subprocess.run(
+                [go_binary, "run", "./go/cmd/sentiment_optimizer"],
+                input=json.dumps(payload).encode("utf-8"),
+                capture_output=True,
+                check=True,
+                cwd=self._repo_root,
+                timeout=8,
+            )
+        except subprocess.TimeoutExpired:
+            print("⚠️ Go optimizer timed out; continuing without adjustments.")
+            return None
+        except subprocess.CalledProcessError as exc:
+            stderr = exc.stderr.decode("utf-8", errors="ignore") if exc.stderr else ""
+            print(
+                f"⚠️ Go optimizer failed with exit code {exc.returncode}: {stderr.strip()}"
+            )
+            return None
+        except FileNotFoundError:
+            if not self._go_missing_logged:
+                print("⚠️ Go toolchain not found. Skipping optimizer step.")
+                self._go_missing_logged = True
+            return None
+
+        raw_output = completed.stdout.decode("utf-8", errors="ignore").strip()
+        if not raw_output:
+            return None
+
+        try:
+            result = json.loads(raw_output)
+        except json.JSONDecodeError:
+            print(f"⚠️ Unable to parse Go optimizer output: {raw_output[:200]}...")
+            return None
+
+        if not isinstance(result, dict):
+            return None
+
+        return result
 
     def analyze_price_based_sentiment(self, price_data: Dict, symbol: str) -> Dict:
         """
@@ -315,7 +535,11 @@ class SentimentAnalyzer:
             raise Exception(f"Price analysis failed for {symbol}: {str(e)}")
 
     def analyze_news_sentiment(
-        self, news_articles: List[Dict], ai_provider: str = None, symbol: str = None
+        self,
+        news_articles: List[Dict],
+        ai_provider: str = None,
+        symbol: str = None,
+        historical_sentiment: Optional[List[Dict]] = None,
     ) -> Dict:
         """
         Analyze sentiment of news articles using AI (Ollama, DeepSeek or OpenAI)
@@ -324,6 +548,8 @@ class SentimentAnalyzer:
             news_articles: List of news articles to analyze
             ai_provider: 'ollama', 'deepseek' or 'openai' - if None, uses preferred provider
             symbol: Stock symbol for context and weighting stock-specific news
+            historical_sentiment: Optional historical sentiment performance records used to
+                nudge weighting and post-processing using the Go optimizer helper
         """
         if not news_articles:
             raise Exception("No news articles provided for analysis")
@@ -351,6 +577,20 @@ class SentimentAnalyzer:
                 summary = article.get(
                     "summary", article.get("description", article.get("selftext", ""))
                 )
+                source_field = article.get("source")
+                if isinstance(source_field, dict):
+                    source_name = source_field.get("name")
+                else:
+                    source_name = source_field
+                source_name = source_name or article.get("site") or article.get("publisher")
+                published_raw = (
+                    article.get("published_at")
+                    or article.get("publishedAt")
+                    or article.get("datetime")
+                    or article.get("created_at")
+                    or article.get("time_published")
+                )
+                published_at = self._normalize_timestamp(published_raw)
             else:
                 # If article is not a dict, skip it
                 print(f"Warning: Skipping non-dict article: {type(article)}")
@@ -368,6 +608,8 @@ class SentimentAnalyzer:
                             "headline": headline,
                             "summary": summary,
                             "weight": 3.0,  # Higher weight for stock-specific news
+                            "source": source_name,
+                            "published_at": published_at,
                         }
                     )
                 else:
@@ -376,6 +618,8 @@ class SentimentAnalyzer:
                             "headline": headline,
                             "summary": summary,
                             "weight": 1.0,  # Lower weight for general news
+                            "source": source_name,
+                            "published_at": published_at,
                         }
                     )
 
@@ -385,29 +629,42 @@ class SentimentAnalyzer:
         if not combined_news:
             raise Exception("No valid news content found in articles")
 
-        # Build weighted news text
-        news_text = ""
-        total_weight = 0
+        historical_rows = (
+            historical_sentiment
+            if historical_sentiment is not None
+            else self._load_historical_sentiment(symbol)
+        )
 
-        for article in combined_news:
-            weight = article["weight"]
-            total_weight += weight
+        go_optimizer_result = self._optimize_with_go(combined_news, historical_rows)
+        if go_optimizer_result:
+            weights = go_optimizer_result.get("weights")
+            if isinstance(weights, list) and len(weights) == len(combined_news):
+                for article, new_weight in zip(combined_news, weights):
+                    article["weight"] = self._safe_float(
+                        new_weight, article.get("weight", 1.0)
+                    )
 
-            # Repeat stock-specific news more to give it higher weight
-            repeat_count = int(weight)
-            for _ in range(repeat_count):
-                news_text += f"Headline: {article['headline']}\n"
+        # Build weighted news text and keep the summaries concise for token efficiency
+        news_text, total_weight, prompt_articles = self._build_weighted_prompt(
+            combined_news
+        )
+        raw_prompt_length = len(news_text)
 
         # Limit text length to prevent Ollama timeouts (reduced for faster processing)
-        max_text_length = 800
-        if len(news_text) > max_text_length:
+        max_text_length = 1600
+        if raw_prompt_length > max_text_length:
             print(
-                f"⚠️  Truncating news text from {len(news_text)} to {max_text_length} characters to prevent timeout"
+                f"⚠️  Truncating news text from {raw_prompt_length} to {max_text_length} characters to prevent timeout"
             )
-            news_text = (
-                news_text[:max_text_length]
-                + "\n\n[Content truncated due to length limits]"
-            )
+            truncated_text = news_text[:max_text_length]
+            last_break = truncated_text.rfind("\n")
+            if last_break > max_text_length * 0.6:
+                news_text = (
+                    truncated_text[:last_break]
+                    + "\n[Content truncated due to length limits]"
+                )
+            else:
+                news_text = truncated_text + "…"
 
         # Determine if this is crypto analysis
         is_crypto = symbol and any(
@@ -460,8 +717,11 @@ Return JSON: {{"sentiment_score": float, "confidence": float, "summary": "string
             print(f"   Stock-specific news: {len(stock_specific_news)} articles")
             print(f"   General news: {len(general_news)} articles")
             print(f"   Total weight: {total_weight}")
-            print(f"   News text length: {len(news_text)} characters")
-            if len(news_text) < 100:
+            print(
+                f"   News text length: {raw_prompt_length} characters (post-truncation {len(news_text)})"
+            )
+            print(f"   Articles included in prompt: {prompt_articles}")
+            if raw_prompt_length < 100:
                 print(f"   ⚠️  WARNING: Very short news text: '{news_text}'")
             try:
                 response = self._call_ollama_api(messages)
@@ -710,12 +970,50 @@ Return JSON: {{"sentiment_score": float, "confidence": float, "summary": "string
             if combined_news
             else 0,
             "is_crypto": is_crypto,
+            "prompt_articles": prompt_articles,
+            "prompt_characters": len(news_text),
+            "prompt_characters_raw": raw_prompt_length,
         }
+
+        analysis_metadata["historical_records_used"] = len(historical_rows or [])
+        if go_optimizer_result:
+            analysis_metadata["go_optimizer"] = {
+                "baseline_shift": go_optimizer_result.get("baseline_shift"),
+                "confidence_adjustment": go_optimizer_result.get(
+                    "confidence_adjustment"
+                ),
+                "notes": go_optimizer_result.get("notes"),
+                "diagnostics": go_optimizer_result.get("diagnostics"),
+            }
+
+        summary_text = result.get("summary", "Analysis completed")
+
+        if go_optimizer_result:
+            baseline_shift = go_optimizer_result.get("baseline_shift")
+            if isinstance(baseline_shift, (int, float)):
+                sentiment_score = max(
+                    -1.0, min(1.0, sentiment_score + float(baseline_shift))
+                )
+
+            confidence_adjustment = go_optimizer_result.get("confidence_adjustment")
+            if isinstance(confidence_adjustment, (int, float)):
+                confidence = max(
+                    0.0, min(1.0, confidence + float(confidence_adjustment))
+                )
+
+            notes = go_optimizer_result.get("notes")
+            if isinstance(notes, list) and notes:
+                historical_note = "; ".join(str(note) for note in notes[:2] if note)
+                if historical_note:
+                    summary_text = summary_text.rstrip()
+                    if summary_text and not summary_text.endswith(('.', '!', '?')):
+                        summary_text += "."
+                    summary_text += f" Historical context: {historical_note}."
 
         return {
             "sentiment_score": sentiment_score,
             "confidence": confidence,
-            "summary": result.get("summary", "Analysis completed"),
+            "summary": summary_text,
             "provider": provider_used,
             "analysis_metadata": analysis_metadata,
         }


### PR DESCRIPTION
## Summary
- add a Go helper that re-weights news articles with historical sentiment data and exposes baseline/confidence adjustments
- wire the Python sentiment analyzer to call the optimizer, capture optional historical records, and surface diagnostics downstream
- document the non-RAG workflow for leveraging historical data and the new optimizer metadata in the sentiment overview

## Testing
- python -m compileall src/core/sentiment_analyzer.py
- printf '{"articles":[{"weight":3,"headline":"Test","summary":"","source":"Reuters","published_at":"2024-05-01T12:00:00Z"}],"history":[{"sentiment":0.2,"realized_return":0.1,"confidence":0.8,"volume":1200000,"source":"Reuters","timestamp":"2024-05-01T00:00:00Z"}]}' | go run ./go/cmd/sentiment_optimizer


------
https://chatgpt.com/codex/tasks/task_e_68d94887fd00832a8508ec4fa2ff4157