### PR TITLE
Align stocks table styling with logs page container

### DIFF
--- a/src/web/static/css/styles.css
+++ b/src/web/static/css/styles.css
@@ -1122,6 +1122,18 @@ table {
     overflow-y: auto;
 }
 
+#stocksTableContainer {
+    background: var(--bs-card-bg);
+    border: 1px solid var(--bs-border-color);
+    border-radius: 0.375rem;
+    max-height: 600px;
+    overflow-y: auto;
+}
+
+#stocksTableContainer table {
+    margin-bottom: 0;
+}
+
 /* Button loading states */
 .btn-loading {
     position: relative;

--- a/src/web/templates/stocks.html
+++ b/src/web/templates/stocks.html
@@ -229,7 +229,7 @@
                 <h5><i class="fas fa-table"></i> Analysis Results</h5>
             </div>
             <div class="card-body">
-                <div class="table-responsive">
+                <div id="stocksTableContainer" class="table-responsive">
                     <table class="table table-striped table-hover" id="stocksTable">
                         <thead class="table-dark">
                             <tr>


### PR DESCRIPTION
## Summary
- wrap the legacy stocks analysis table in a styled container mirroring the logs page layout
- add shared styling so the stocks table uses the same bordered background and scrolling behavior as the logs container

## Testing
- python start_app.py *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68e6860de4a4832a9d2e34610da3ea36