### PR TITLE
Add mobile app development plan

### DIFF
--- a/docs/mobile_app_plan.md
+++ b/docs/mobile_app_plan.md
@@ -1,0 +1,89 @@
+# Mobile App Development Plan
+
+## Goal
+Deliver native-quality iOS and Android applications for the Trading AI platform that are eligible for paid distribution via the Apple App Store and Google Play Store, reusing existing backend services where possible while meeting each store's review and compliance requirements.
+
+## Phase 0 – Discovery & Architecture (2 weeks)
+- **Stakeholder alignment:** Confirm product scope, revenue model (paid download vs. in-app purchases/subscriptions), and targeted release countries.
+- **Technical audit:**
+  - Review current Flask backend for API completeness, authentication flows, and rate limits.
+  - Inventory required data feeds (real-time quotes, historical data, AI recommendations) and identify any licensing restrictions for mobile redistribution.
+  - Assess existing infrastructure for mobile traffic scaling and security (HTTPS, WAF, monitoring).
+- **Architecture decisions:**
+  - Choose cross-platform stack (e.g., React Native with TypeScript) to maximize code sharing while enabling native performance-critical modules.
+  - Define mobile backend gateway (GraphQL or REST) and auth (OAuth 2.0 / JWT refresh flow).
+- **Compliance analysis:** Map App Store Review Guidelines and Google Play policies to app features; identify data privacy, trading disclaimers, and financial compliance content.
+
+## Phase 1 – Backend & Platform Hardening (3–4 weeks)
+- **API stabilization:**
+  - Formalize versioned mobile API endpoints with OpenAPI specs.
+  - Implement pagination, caching, and request throttling suitable for mobile clients.
+- **Authentication & payments:**
+  - Implement OAuth-compliant sign-in supporting Sign in with Apple and Google Sign-In.
+  - Integrate Apple StoreKit 2 and Google Play Billing server-side validation endpoints for paid downloads or subscription entitlements.
+- **Security & compliance:**
+  - Enforce HTTPS with TLS 1.2+, certificate pinning support, and HSTS.
+  - Add audit logging for mobile-specific transactions.
+  - Prepare legal disclosures, risk warnings, and privacy policy endpoints.
+- **CI/CD foundation:** Create automated tests (unit, contract, integration) for mobile APIs and add mobile client schemas to monitoring dashboards.
+
+## Phase 2 – Mobile Client Foundations (5–6 weeks)
+- **Project setup:**
+  - Initialize React Native monorepo with TypeScript, ESLint, Jest, and Detox for end-to-end tests.
+  - Configure native modules for charts (e.g., `react-native-reanimated`, `react-native-svg`) and secure storage (`react-native-keychain`).
+- **Design system:**
+  - Translate existing web design tokens into a mobile style guide (colors, typography, spacing).
+  - Build reusable UI components (buttons, cards, charts, modals) with accessibility compliance (WCAG 2.1 AA).
+- **Navigation & state management:** Implement React Navigation with authenticated/guest flows and Redux Toolkit (or Recoil) for global state.
+- **Feature parity baseline:**
+  - Dashboards: AI insights, portfolio overview, real-time watchlists.
+  - Trade simulator or broker integration as applicable.
+  - Notifications: push notification setup via Firebase Cloud Messaging (Android) and Apple Push Notification service (APNs).
+- **Local data handling:** Offline caching for watchlists and historical charts using SQLite or MMKV.
+
+## Phase 3 – Monetization & App Store Integration (3 weeks)
+- **Paid distribution configuration:**
+  - Apple: Configure App Store Connect paid app, pricing tiers, tax/ banking info, and App Privacy details.
+  - Google: Set up Play Console paid app, pricing templates, and manage Play Payments profile.
+- **In-app purchase / subscription logic (if needed):** Implement paywall UX, entitlements store, and receipt validation handshake with backend.
+- **Store assets:** Produce marketing copy, localized descriptions, screenshots, preview videos, and privacy labels.
+- **Beta distribution:**
+  - Apple TestFlight for internal and external testers.
+  - Google Play internal testing and closed testing tracks.
+
+## Phase 4 – Quality Assurance & Launch Readiness (3 weeks)
+- **Automated testing:** Expand unit, integration, and E2E suites across devices; set up CI pipelines (GitHub Actions or Bitrise) for build/test/deploy.
+- **Manual QA:** Device lab testing (iPhone SE/14 Pro, Pixel 6/7, Samsung Galaxy series); verify accessibility, dark mode, and localization.
+- **Performance tuning:** Optimize bundle size, startup time, network usage, and battery consumption.
+- **Security review:** Perform static analysis (MobSF), dynamic testing, and penetration testing for mobile clients and APIs.
+- **App Store compliance review:** Checklist for App Review guidelines (account creation, content, payments, user-generated content policies).
+
+## Phase 5 – Launch & Post-Launch (ongoing)
+- **Submission:** Submit to App Store Review and Google Play review, respond to reviewer feedback promptly.
+- **Release monitoring:** Track crash analytics (Sentry, Firebase Crashlytics), performance metrics, and store reviews.
+- **Support & iteration:** Establish feedback channels, roadmap post-launch enhancements (widgets, wearables, advanced analytics).
+- **Growth:** Plan UA campaigns, ASO, referral programs, and partnerships with brokerages.
+
+## Dependencies & Roles
+- **Mobile engineers (2–3)** experienced in React Native / native modules.
+- **Backend engineer (1–2)** for API hardening and payment integration.
+- **DevOps/SRE (1)** for infrastructure scaling and CI/CD.
+- **Designer (1)** for mobile UX and marketing assets.
+- **QA engineer (1)** dedicated to mobile testing.
+- **Compliance/legal advisor (shared)** for financial and privacy requirements.
+
+## Estimated Timeline
+- Total initial release effort: ~16–18 weeks (overlapping phases where possible).
+- Post-launch iteration: ongoing sprints focusing on user feedback and new features.
+
+## Risks & Mitigations
+- **App store rejection:** Mitigate with early guideline alignment, TestFlight feedback, and privacy transparency.
+- **Data feed licensing limits:** Secure mobile redistribution rights or adjust feature set.
+- **Payment compliance:** Adhere to Apple/Google in-app payment policies; plan for regional regulations (GDPR, CCPA).
+- **Scalability:** Load-test backend for peak mobile usage; implement auto-scaling and monitoring.
+
+## Deliverables
+- Published iOS and Android apps with paid download or subscription monetization enabled.
+- Hardened backend API with monitoring and analytics tailored for mobile clients.
+- Documentation: architecture diagrams, API specs, ops runbooks, app store submission checklists.
+- QA artifacts: test plans, automated test coverage reports, compliance sign-off.


### PR DESCRIPTION
## Summary
- add a detailed plan for building paid-distribution iOS and Android clients
- outline backend hardening, mobile client development, monetization, QA, and launch phases
- document team roles, timeline, risks, and deliverables for mobile app rollout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8ff346764832aa9eb9d1714c71fca